### PR TITLE
feat(grafana): add Drupal logs dashboard

### DIFF
--- a/kubernetes/apps/observability/grafana/app/grafanadashboard-drupal-logs.yaml
+++ b/kubernetes/apps/observability/grafana/app/grafanadashboard-drupal-logs.yaml
@@ -1,0 +1,193 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: drupal-logs
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  json: |
+    {
+      "title": "Drupal Logs",
+      "uid": "drupal-logs",
+      "description": "Drupal application logs from Loki — filterable by namespace, pod, container and free-text search",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "timezone": "browser",
+      "time": { "from": "now-1h", "to": "now" },
+      "timepicker": {},
+      "tags": ["drupal", "loki", "logs"],
+      "editable": true,
+      "graphTooltip": 0,
+      "links": [],
+      "annotations": { "list": [] },
+      "templating": {
+        "list": [
+          {
+            "name": "datasource",
+            "type": "datasource",
+            "pluginId": "loki",
+            "label": "Datasource",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "options": [],
+            "query": "loki",
+            "refresh": 1,
+            "regex": ""
+          },
+          {
+            "name": "namespace",
+            "type": "query",
+            "label": "Namespace",
+            "datasource": { "type": "loki", "uid": "${datasource}" },
+            "definition": "label_values(namespace)",
+            "query": "label_values(namespace)",
+            "regex": "hietamakidojo|gpro|paikky|leo-cal|ruskonkesateatteri",
+            "sort": 1,
+            "refresh": 2,
+            "hide": 0,
+            "multi": true,
+            "includeAll": true,
+            "allValue": ".+",
+            "options": [],
+            "current": {}
+          },
+          {
+            "name": "pod",
+            "type": "query",
+            "label": "Pod",
+            "datasource": { "type": "loki", "uid": "${datasource}" },
+            "definition": "label_values({namespace=~\"$namespace\"}, pod)",
+            "query": "label_values({namespace=~\"$namespace\"}, pod)",
+            "regex": "",
+            "sort": 1,
+            "refresh": 2,
+            "hide": 0,
+            "multi": true,
+            "includeAll": true,
+            "allValue": ".+",
+            "options": [],
+            "current": {}
+          },
+          {
+            "name": "container",
+            "type": "query",
+            "label": "Container",
+            "datasource": { "type": "loki", "uid": "${datasource}" },
+            "definition": "label_values({namespace=~\"$namespace\", pod=~\"$pod\"}, container)",
+            "query": "label_values({namespace=~\"$namespace\", pod=~\"$pod\"}, container)",
+            "regex": "",
+            "sort": 1,
+            "refresh": 2,
+            "hide": 0,
+            "multi": true,
+            "includeAll": true,
+            "allValue": ".+",
+            "options": [],
+            "current": {}
+          },
+          {
+            "name": "search",
+            "type": "textbox",
+            "label": "Search",
+            "hide": 0,
+            "query": "",
+            "current": { "selected": true, "text": "", "value": "" },
+            "options": [{ "selected": true, "text": "", "value": "" }],
+            "skipUrlSync": false
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Log Volume",
+          "type": "timeseries",
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 80,
+                "stacking": { "group": "A", "mode": "normal" },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "axisPlacement": "auto",
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "barAlignment": 0,
+                "gradientMode": "none",
+                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "scaleDistribution": { "type": "linear" },
+                "showPoints": "never",
+                "spanNulls": false,
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [{ "color": "green", "value": null }]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "loki", "uid": "${datasource}" },
+              "editorMode": "code",
+              "expr": "sum by (namespace) (count_over_time({namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |= \"$search\" [$__auto]))",
+              "legendFormat": "{{namespace}}",
+              "queryType": "range"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "title": "Logs",
+          "type": "logs",
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "gridPos": { "h": 30, "w": 24, "x": 0, "y": 8 },
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": true,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "loki", "uid": "${datasource}" },
+              "editorMode": "code",
+              "expr": "{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |= \"$search\"",
+              "queryType": "range"
+            }
+          ]
+        }
+      ]
+    }

--- a/kubernetes/apps/observability/grafana/app/grafanadashboard-drupal-logs.yaml
+++ b/kubernetes/apps/observability/grafana/app/grafanadashboard-drupal-logs.yaml
@@ -13,9 +13,9 @@ spec:
     {
       "title": "Drupal Logs",
       "uid": "drupal-logs",
-      "description": "Drupal application logs from Loki — filterable by namespace, pod, container and free-text search",
+      "description": "Drupal application logs from Loki — filterable by namespace, pod, container, log type and free-text search",
       "schemaVersion": 39,
-      "version": 1,
+      "version": 2,
       "refresh": "30s",
       "timezone": "browser",
       "time": { "from": "now-1h", "to": "now" },
@@ -92,6 +92,26 @@ spec:
             "current": {}
           },
           {
+            "name": "log_type",
+            "type": "custom",
+            "label": "Drupal Log Type",
+            "hide": 0,
+            "multi": false,
+            "includeAll": false,
+            "query": "All : .*,php : php,user : user,page not found : page not found,access denied : access denied,content : content,system : system,cron : cron",
+            "options": [
+              { "selected": true,  "text": "All",              "value": ".*" },
+              { "selected": false, "text": "php",              "value": "php" },
+              { "selected": false, "text": "user",             "value": "user" },
+              { "selected": false, "text": "page not found",   "value": "page not found" },
+              { "selected": false, "text": "access denied",    "value": "access denied" },
+              { "selected": false, "text": "content",          "value": "content" },
+              { "selected": false, "text": "system",           "value": "system" },
+              { "selected": false, "text": "cron",             "value": "cron" }
+            ],
+            "current": { "selected": true, "text": "All", "value": ".*" }
+          },
+          {
             "name": "search",
             "type": "textbox",
             "label": "Search",
@@ -144,12 +164,7 @@ spec:
             "overrides": []
           },
           "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
+            "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
           "targets": [
@@ -165,10 +180,11 @@ spec:
         },
         {
           "id": 2,
-          "title": "Logs",
+          "title": "All Pod Logs",
+          "description": "Raw logs from all containers — php-fpm access log, nginx access log, and Drupal syslog combined",
           "type": "logs",
           "datasource": { "type": "loki", "uid": "${datasource}" },
-          "gridPos": { "h": 30, "w": 24, "x": 0, "y": 8 },
+          "gridPos": { "h": 22, "w": 24, "x": 0, "y": 8 },
           "options": {
             "dedupStrategy": "none",
             "enableLogDetails": true,
@@ -185,6 +201,33 @@ spec:
               "datasource": { "type": "loki", "uid": "${datasource}" },
               "editorMode": "code",
               "expr": "{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |= \"$search\"",
+              "queryType": "range"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "title": "Drupal Watchdog Logs",
+          "description": "Only Drupal syslog/watchdog entries (pipe-delimited format). Use the 'Drupal Log Type' filter to narrow by type. Requires Syslog module + syslog-to-stdout forwarding in the container.",
+          "type": "logs",
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "gridPos": { "h": 22, "w": 24, "x": 0, "y": 30 },
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": true,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "loki", "uid": "${datasource}" },
+              "editorMode": "code",
+              "expr": "{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |= \"$search\" | regexp \"\\]: [^|]+\\|[^|]+\\|(?P<log_type>[^|]+)\\|\" | log_type =~ \"^$log_type$\"",
               "queryType": "range"
             }
           ]

--- a/kubernetes/apps/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/app/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 resources:
   - ./external-secret.yaml
   - ./grafanadashboard.yaml
+  - ./grafanadashboard-drupal-logs.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
## Summary

- Adds a `GrafanaDashboard` CRD (`drupal-logs`) that displays Drupal application logs from Loki
- Dashboard is filterable by **datasource**, **namespace** (pre-scoped to `hietamakidojo`, `gpro`, `paikky`, `leo-cal`, `ruskonkesateatteri`), **pod**, **container**, and a free-text **search** box
- Includes a stacked **Log Volume** timeseries panel and a full **Logs** panel with label display, time, and expandable log details
- Registered in the grafana app `kustomization.yaml` so Flux picks it up automatically

## Test plan

- [ ] Confirm `GrafanaDashboard/drupal-logs` is reconciled by the grafana-operator
- [ ] Open Grafana → Dashboards → "Drupal Logs" and verify the namespace dropdown lists the Drupal namespaces
- [ ] Select a namespace, confirm pod/container dropdowns cascade correctly
- [ ] Type a search term (e.g. `watchdog`, `php`, `user`) and confirm logs are filtered
- [ ] Verify log volume bars update with the same filters

https://claude.ai/code/session_013S9FgBh3qqj3BXduhCUBpn

---
_Generated by [Claude Code](https://claude.ai/code/session_013S9FgBh3qqj3BXduhCUBpn)_