### PR TITLE
fix(traefik): bump chart to 41.0.2 to stop bundling Gateway API CRDs

### DIFF
--- a/kubernetes/apps/network/traefik/app/helmrelease.yaml
+++ b/kubernetes/apps/network/traefik/app/helmrelease.yaml
@@ -93,27 +93,26 @@ spec:
     api:
       dashboard: true
       insecure: true
-    logs:
-      general:
-        level: INFO
-      access:
-        enabled: true
-        format: json
-        fields:
+    log:
+      level: INFO
+    accessLog:
+      enabled: true
+      format: json
+      fields:
+        defaultMode: keep
+        names:
+          ClientUsername: drop
+        headers:
           defaultMode: keep
           names:
-            ClientUsername: drop
-          headers:
-            defaultMode: keep
-            names:
-              Authorization: drop
-              User-Agent: keep
-              CF-Connecting-IP: keep
-              X-Forwarded-For: keep
-              X-Real-IP: keep
-              X-Forwarded-Host: keep
-              X-Forwarded-Port: keep
-              X-Forwarded-Proto: keep
+            Authorization: drop
+            User-Agent: keep
+            CF-Connecting-IP: keep
+            X-Forwarded-For: keep
+            X-Real-IP: keep
+            X-Forwarded-Host: keep
+            X-Forwarded-Port: keep
+            X-Forwarded-Proto: keep
     experimental:
       localPlugins:
         authentik-forward:

--- a/kubernetes/apps/network/traefik/app/ocirepository.yaml
+++ b/kubernetes/apps/network/traefik/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 39.0.0
+    tag: 41.0.2
   url: oci://ghcr.io/traefik/helm/traefik


### PR DESCRIPTION
## Problem

The traefik HelmRelease has failed every upgrade since 2026-06-10:

```
ValidatingAdmissionPolicy 'safe-upgrades.gateway.networking.k8s.io' denied request:
Installing CRDs with version before v1.5.0 is prohibited by default.
```

Chart 39.0.0 bundles Gateway API **v1.4.0** CRDs in its `crds/` directory, while the cluster runs the manually-installed **v1.5.1** CRDs. Helm tries to replace (downgrade) them on every upgrade and the safe-upgrades policy correctly denies it.

## Fix

- Bump the chart `39.0.0 → 41.0.2` — Traefik stopped shipping Gateway API CRDs in chart 41.x, so the conflict disappears. Traefik itself goes v3.6.7 → v3.7.6.
- Migrate values for the chart-40 rename: `logs.general` → `log`, `logs.access` → `accessLog` (same content).

## Verification

`helm template` of 41.0.2 with the migrated values passes the chart's values schema and renders identically for everything we care about: 4 replicas, plugin-loader initContainer, `envFrom` OIDC secret, JSON access log with the field/header modes, HTTP/3 on websecure, kubernetesGateway+CRD providers, Cilium LB IP annotation `192.168.7.4`, and the responding-timeout args.

## Notes

- Gateway API CRDs remain out-of-band (kubectl-applied v1.5.1); committing them to git is a follow-up.
- `service.externalTrafficPolicy: Local` in the values has never rendered in chart 39 or 41 (live Service is `Cluster`) — the chart expects `service.spec.externalTrafficPolicy`. Left as-is to avoid a behavior change; separate decision.