### PR TITLE
feat(media): add Posterizarr for automated Plex poster generation

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./configarr/ks.yaml
   - ./kometa/ks.yaml
   - ./maintainerr/ks.yaml
+  - ./posterizarr/ks.yaml
   - ./prowlarr/ks.yaml
   - ./seerr/ks.yaml
   - ./radarr/ks.yaml

--- a/kubernetes/apps/media/posterizarr/app/external-secret.yaml
+++ b/kubernetes/apps/media/posterizarr/app/external-secret.yaml
@@ -1,0 +1,313 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: posterizarr-secret
+  namespace: media
+spec:
+  refreshInterval: 1h
+  target:
+    name: posterizarr-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      data:
+        # Full Posterizarr config - rendered here because it embeds API tokens.
+        # An initContainer copies it onto the /config PVC at pod start, so git
+        # stays the source of truth across restarts while the app can still
+        # write to the file at runtime.
+        # Inspired by bullmoose20's community config:
+        # https://github.com/Kometa-Team/Community-Configs/blob/master/bullmoose20/posterizarr/bullmoose20config.json
+        config.json: |
+          {
+            "ApiPart": {
+              "tvdbapi": "{{ .tvdbapi }}",
+              "tmdbtoken": "{{ .tmdbtoken }}",
+              "FanartTvAPIKey": "{{ .fanarttvapikey }}",
+              "PlexToken": "{{ .plextoken }}",
+              "JellyfinAPIKey": "unused",
+              "EmbyAPIKey": "unused",
+              "FavProvider": "tmdb",
+              "PreferredLanguageOrder": ["xx"],
+              "PreferredSeasonLanguageOrder": ["xx"],
+              "PreferredBackgroundLanguageOrder": ["xx"],
+              "PreferredTCLanguageOrder": ["xx"],
+              "LogoLanguageOrder": ["en"],
+              "tmdb_vote_sorting": "vote_average",
+              "WidthHeightFilter": "false",
+              "PosterMinWidth": "2000",
+              "PosterMinHeight": "3000",
+              "BgTcMinWidth": "3840",
+              "BgTcMinHeight": "2160"
+            },
+            "PlexPart": {
+              "LibstoExclude": [],
+              "PlexUrl": "https://plex.vaderrp.com",
+              "UsePlex": "true",
+              "UploadExistingAssets": "false"
+            },
+            "JellyfinPart": {
+              "LibstoExclude": [],
+              "JellyfinUrl": "http://localhost:8096",
+              "UseJellyfin": "false",
+              "UploadExistingAssets": "false",
+              "ReplaceThumbwithBackdrop": "false"
+            },
+            "EmbyPart": {
+              "LibstoExclude": [],
+              "EmbyUrl": "http://localhost:8096",
+              "UseEmby": "false",
+              "UploadExistingAssets": "false",
+              "ReplaceThumbwithBackdrop": "false"
+            },
+            "Notification": {
+              "SendNotification": "false",
+              "AppriseUrl": "",
+              "Discord": "",
+              "UseUptimeKuma": "false",
+              "UptimeKumaUrl": "",
+              "DiscordUserName": "Posterizarr"
+            },
+            "PrerequisitePart": {
+              "AssetPath": "/assets",
+              "BackupPath": "/assetsbackup",
+              "ManualAssetPath": "/manualassets",
+              "magickinstalllocation": "./magick",
+              "maxLogs": "10",
+              "logLevel": "2",
+              "font": "Comfortaa-Medium.ttf",
+              "backgroundfont": "Comfortaa-Medium.ttf",
+              "titlecardfont": "Comfortaa-Medium.ttf",
+              "collectionfont": "Colus-Regular.ttf",
+              "RTLFont": "Colus-Regular.ttf",
+              "overlayfile": "overlay.png",
+              "backgroundoverlayfile": "bottom-up-fade-background.png",
+              "titlecardoverlayfile": "bottom-up-fade-background.png",
+              "seasonoverlayfile": "bottom-up-fade.png",
+              "collectionoverlayfile": "overlay-innerglow.png",
+              "showoverlayfile": "",
+              "showbackgroundoverlayfile": "",
+              "LibraryFolders": "true",
+              "Posters": "true",
+              "SeasonPosters": "true",
+              "BackgroundPosters": "true",
+              "TitleCards": "true",
+              "show_skipped": "false",
+              "SkipTBA": "true",
+              "SkipJapTitle": "false",
+              "AssetCleanup": "true",
+              "AutoUpdateIM": "false",
+              "AutoUpdatePosterizarr": "false",
+              "NewLineOnSpecificSymbols": "false",
+              "NewLineSymbols": [" - "],
+              "NewLineOnSpecificWords": "false",
+              "NewLineWords": {},
+              "SymbolsToKeepOnNewLine": [],
+              "PlexUpload": "true",
+              "ForceRunningDeletion": "false",
+              "SkipAddText": "false",
+              "SkipAddTextAndBorder": "false",
+              "SkipAddTextAndOverlay": "false",
+              "SkipLocalPosterTextAdd": "false",
+              "SkipLocalBackgroundTextAdd": "false",
+              "SkipLocalSeasonTextAdd": "false",
+              "SkipLocalTCTextAdd": "false",
+              "FollowSymlink": "false",
+              "FileTestOnTrigger": "true",
+              "DisableHashValidation": "false",
+              "DisableOnlineAssetFetch": "false",
+              "UsePosterResolutionOverlays": "false",
+              "UseBackgroundResolutionOverlays": "false",
+              "UseTCResolutionOverlays": "false",
+              "poster4k": "overlay-innerglow.png",
+              "Poster1080p": "overlay-innerglow.png",
+              "Background4k": "backgroundoverlay-innerglow.png",
+              "Background1080p": "backgroundoverlay-innerglow.png",
+              "TC4k": "backgroundoverlay-innerglow.png",
+              "TC1080p": "backgroundoverlay-innerglow.png",
+              "4KDoVi": "overlay-innerglow.png",
+              "4KHDR10": "overlay-innerglow.png",
+              "4KDoViHDR10": "overlay-innerglow.png",
+              "4KDoViBackground": "backgroundoverlay-innerglow.png",
+              "4KHDR10Background": "backgroundoverlay-innerglow.png",
+              "4KDoViHDR10Background": "backgroundoverlay-innerglow.png",
+              "4KDoViTC": "backgroundoverlay-innerglow.png",
+              "4KHDR10TC": "backgroundoverlay-innerglow.png",
+              "4KDoViHDR10TC": "backgroundoverlay-innerglow.png",
+              "UseLogo": "true",
+              "UseClearlogo": "true",
+              "UseClearart": "false",
+              "LogoTextFallback": "true",
+              "UseBGLogo": "false",
+              "ConvertLogoColor": "false",
+              "LogoFlatColor": "white",
+              "UseOriginalTitle": "false"
+            },
+            "OverlayPart": {
+              "ImageProcessing": "true",
+              "outputQuality": "92%"
+            },
+            "PosterOverlayPart": {
+              "fontAllCaps": "true",
+              "fontcolor": "white",
+              "bordercolor": "white",
+              "minPointSize": "83",
+              "maxPointSize": "250",
+              "borderwidth": "30",
+              "strokecolor": "black",
+              "strokewidth": "6",
+              "lineSpacing": "0",
+              "AddBorder": "false",
+              "AddText": "true",
+              "AddTextStroke": "false",
+              "AddOverlay": "true",
+              "MaxWidth": "1200",
+              "MaxHeight": "485",
+              "text_offset": "+300",
+              "TextGravity": "south"
+            },
+            "SeasonPosterOverlayPart": {
+              "fontAllCaps": "true",
+              "fontcolor": "white",
+              "bordercolor": "white",
+              "minPointSize": "100",
+              "maxPointSize": "250",
+              "borderwidth": "30",
+              "strokecolor": "black",
+              "strokewidth": "6",
+              "lineSpacing": "0",
+              "AddBorder": "false",
+              "AddText": "true",
+              "AddTextStroke": "false",
+              "AddOverlay": "true",
+              "MaxWidth": "1200",
+              "MaxHeight": "485",
+              "text_offset": "+300",
+              "TextGravity": "south",
+              "ShowFallback": "false"
+            },
+            "BackgroundOverlayPart": {
+              "fontAllCaps": "true",
+              "fontcolor": "white",
+              "bordercolor": "white",
+              "minPointSize": "95",
+              "maxPointSize": "250",
+              "borderwidth": "30",
+              "strokecolor": "black",
+              "strokewidth": "6",
+              "lineSpacing": "0",
+              "AddOverlay": "true",
+              "AddBorder": "false",
+              "AddText": "false",
+              "AddTextStroke": "false",
+              "MaxWidth": "3000",
+              "MaxHeight": "500",
+              "text_offset": "+200",
+              "TextGravity": "south"
+            },
+            "TitleCardOverlayPart": {
+              "bordercolor": "white",
+              "borderwidth": "30",
+              "UseBackgroundAsTitleCard": "false",
+              "BackgroundFallback": "false",
+              "AddOverlay": "true",
+              "AddBorder": "false",
+              "SkipWords": ["TBA"]
+            },
+            "TitleCardTitleTextPart": {
+              "fontAllCaps": "true",
+              "fontcolor": "white",
+              "minPointSize": "48",
+              "maxPointSize": "140",
+              "strokecolor": "black",
+              "strokewidth": "6",
+              "lineSpacing": "0",
+              "AddEPTitleText": "true",
+              "AddTextStroke": "false",
+              "MaxWidth": "2500",
+              "MaxHeight": "300",
+              "text_offset": "-150",
+              "TextGravity": "south"
+            },
+            "TitleCardEPTextPart": {
+              "fontAllCaps": "true",
+              "fontcolor": "white",
+              "minPointSize": "48",
+              "maxPointSize": "80",
+              "strokecolor": "black",
+              "strokewidth": "6",
+              "lineSpacing": "0",
+              "SeasonTCText": "false",
+              "AddEPText": "true",
+              "AddTextStroke": "false",
+              "MaxWidth": "2500",
+              "MaxHeight": "150",
+              "text_offset": "+100",
+              "TextGravity": "south"
+            },
+            "CollectionTitlePosterPart": {
+              "fontAllCaps": "true",
+              "fontcolor": "white",
+              "bordercolor": "white",
+              "minPointSize": "83",
+              "maxPointSize": "250",
+              "borderwidth": "30",
+              "strokecolor": "black",
+              "strokewidth": "6",
+              "lineSpacing": "0",
+              "AddBorder": "false",
+              "AddText": "true",
+              "AddCollectionTitle": "true",
+              "CollectionTitle": "COLLECTION",
+              "AddTextStroke": "false",
+              "AddOverlay": "true",
+              "MaxWidth": "1200",
+              "MaxHeight": "485",
+              "text_offset": "+300",
+              "TextGravity": "south"
+            }
+          }
+  data:
+    # Plex Token (shared kometa/posterizarr media item)
+    - secretKey: plextoken
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        key: 82de75a5-08e1-4f8c-82a3-1b45d067e78e
+        property: plextoken
+
+    # TMDb API *Read Access Token* (the long v4 bearer token, NOT the v3
+    # apikey kometa uses). TODO: add a "tmdbtoken" field to the item.
+    - secretKey: tmdbtoken
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        key: 82de75a5-08e1-4f8c-82a3-1b45d067e78e
+        property: tmdbtoken
+
+    # TVDB API key (free at thetvdb.com/api-information).
+    # TODO: add a "tvdbapi" field to the item.
+    - secretKey: tvdbapi
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        key: 82de75a5-08e1-4f8c-82a3-1b45d067e78e
+        property: tvdbapi
+
+    # Fanart.tv personal API key (free at fanart.tv/get-an-api-key).
+    # TODO: add a "fanarttvapikey" field to the item.
+    - secretKey: fanarttvapikey
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        key: 82de75a5-08e1-4f8c-82a3-1b45d067e78e
+        property: fanarttvapikey

--- a/kubernetes/apps/media/posterizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/posterizarr/app/helmrelease.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: posterizarr
+  namespace: media
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: posterizarr
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: posterizarr-values

--- a/kubernetes/apps/media/posterizarr/app/httproute.yaml
+++ b/kubernetes/apps/media/posterizarr/app/httproute.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: posterizarr
+  namespace: media
+  labels:
+    route.scope: external
+  annotations:
+    external-dns.alpha.kubernetes.io/target: external.vaderrp.com
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Media
+    gethomepage.dev/name: Posterizarr
+    gethomepage.dev/icon: posterizarr.png
+    gethomepage.dev/href: https://posterizarr.vaderrp.com
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=posterizarr
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-public
+      namespace: network
+  hostnames:
+    - posterizarr.vaderrp.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: traefik-warp
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: oidc-auth
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: posterizarr
+          port: 8000
+          weight: 1

--- a/kubernetes/apps/media/posterizarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/posterizarr/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ocirepository.yaml
+  - helmrelease.yaml
+  - external-secret.yaml
+  - pvc.yaml
+  - httproute.yaml
+  - vpa.yaml
+
+configMapGenerator:
+  - name: posterizarr-values
+    files:
+      - values.yaml
+    options:
+      disableNameSuffixHash: true # Optional, keeps name clean

--- a/kubernetes/apps/media/posterizarr/app/ocirepository.yaml
+++ b/kubernetes/apps/media/posterizarr/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: posterizarr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/posterizarr/app/pvc.yaml
+++ b/kubernetes/apps/media/posterizarr/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+# Generated poster/background/titlecard assets. Not VolSync-backed —
+# everything here can be regenerated from the media servers and APIs.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: posterizarr-assets
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: local-path

--- a/kubernetes/apps/media/posterizarr/app/values.yaml
+++ b/kubernetes/apps/media/posterizarr/app/values.yaml
@@ -1,0 +1,111 @@
+---
+# Helm values for posterizarr app-template deployment
+controllers:
+  posterizarr:
+    annotations:
+      reloader.stakater.com/auto: "true"
+    strategy: Recreate
+    initContainers:
+      copy-config:
+        image:
+          repository: docker.io/library/busybox
+          tag: 1.37.0
+        command:
+          - sh
+          - -c
+          - cp /secret/config.json /config/config.json
+    containers:
+      app:
+        image:
+          repository: ghcr.io/fscorrupt/posterizarr
+          tag: 3.1.3@sha256:7fb8d115226aedbee60e986c44e57d667f0c4bf93680038601c178d06c1967fb
+        env:
+          TZ: Europe/Helsinki
+          TERM: xterm
+          # Daily run at 05:00, an hour before kometa's overlay/operations run
+          RUN_TIME: "05:00"
+          APP_PORT: &port 8000
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              tcpSocket:
+                port: *port
+              initialDelaySeconds: 30
+              periodSeconds: 30
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              tcpSocket:
+                port: *port
+              initialDelaySeconds: 10
+              periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+        resources:
+          requests:
+            cpu: 25m
+            memory: 512Mi
+          limits:
+            memory: 4Gi
+defaultPodOptions:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 568
+    runAsGroup: 568
+    fsGroup: 568
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile: {type: RuntimeDefault}
+  dnsConfig:
+    options:
+      - name: ndots
+        value: "1"
+      - name: use-vc
+      - name: single-request-reopen
+service:
+  app:
+    controller: posterizarr
+    ports:
+      http:
+        port: 8000
+persistence:
+  config:
+    type: persistentVolumeClaim
+    existingClaim: posterizarr
+    globalMounts:
+      - path: /config
+  secret-config:
+    type: secret
+    name: posterizarr-secret
+    advancedMounts:
+      posterizarr:
+        copy-config:
+          - path: /secret
+  assets:
+    type: persistentVolumeClaim
+    existingClaim: posterizarr-assets
+    advancedMounts:
+      posterizarr:
+        app:
+          - path: /assets
+  assetsbackup:
+    type: emptyDir
+    advancedMounts:
+      posterizarr:
+        app:
+          - path: /assetsbackup
+  manualassets:
+    type: emptyDir
+    advancedMounts:
+      posterizarr:
+        app:
+          - path: /manualassets
+  tmp:
+    type: emptyDir
+    advancedMounts:
+      posterizarr:
+        app:
+          - path: /tmp

--- a/kubernetes/apps/media/posterizarr/app/vpa.yaml
+++ b/kubernetes/apps/media/posterizarr/app/vpa.yaml
@@ -1,0 +1,27 @@
+---
+# Custom VPA for Posterizarr - Burstable QoS
+# Idles between runs, bursts hard during ImageMagick poster generation
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: posterizarr
+  namespace: media
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: posterizarr
+  updatePolicy:
+    updateMode: "Off"  # Recommendation mode only (Goldilocks compatible)
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "app"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly  # Burstable QoS - only manage requests, not limits
+        minAllowed:
+          cpu: 10m
+          memory: 256Mi
+        maxAllowed:
+          cpu: 1000m
+          memory: 2Gi  # Conservative max for requests (limit is 4Gi)
+        mode: "Auto"

--- a/kubernetes/apps/media/posterizarr/ks.yaml
+++ b/kubernetes/apps/media/posterizarr/ks.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: posterizarr
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: posterizarr
+  path: "./kubernetes/apps/media/posterizarr/app"
+  prune: true
+  dependsOn:
+    - name: vpa
+      namespace: observability
+    - name: volsync
+      namespace: storage
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # Default false for speed, enable for critical
+  components:
+    - ../../../../components/volsync-kopia
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: posterizarr
+      VOLSYNC_COPYMETHOD: Direct
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_STORAGECLASS: local-path
+      VOLSYNC_PUID: "568"
+      VOLSYNC_PGID: "568"


### PR DESCRIPTION
## Summary

Adds [Posterizarr](https://github.com/fscorrupt/Posterizarr) (v3.1.3) to the media stack as a follow-up to Kometa (#1583) — it generates styled posters, season posters, backgrounds, and title cards (borders/gradients/title text via ImageMagick) and uploads them directly to Plex. Config is inspired by [bullmoose20's community config](https://github.com/Kometa-Team/Community-Configs/blob/master/bullmoose20/posterizarr/bullmoose20config.json).

## What's included

- **`kubernetes/apps/media/posterizarr/ks.yaml`** — Flux Kustomization with the `volsync-kopia` component (5Gi `local-path` config PVC), depending on `vpa` and `volsync`.
- **`app/values.yaml`** — bjw-s app-template **Deployment** of `ghcr.io/fscorrupt/posterizarr:3.1.3` (digest-pinned):
  - Long-running with the v3 **web UI on port 8000**; `RUN_TIME=05:00` schedules the daily run an hour before Kometa's 06:00 so Kometa's overlays land on fresh posters.
  - An **initContainer copies the rendered config.json** from the secret onto the `/config` PVC at pod start — git stays the source of truth across restarts while the app can still write the file at runtime (UI edits last until the next restart).
  - Separate **20Gi assets PVC** (not VolSync-backed — regenerable), emptyDirs for `/assetsbackup` and `/manualassets`. Standard 568 non-root security context.
- **`app/external-secret.yaml`** — renders the full `config.json` (it embeds four API tokens, so the whole file is secret material):
  - Textless poster preference (`"xx"` language order), TMDb as favourite provider, English logos.
  - Posters, season posters, backgrounds, and title cards enabled; `PlexUpload: true` (direct upload — no shared asset volume with the Kometa CronJob); notifications off; auto-updates off (Renovate owns the image).
  - Overlay/text styling carried over from bullmoose20 (bottom-up fades, Comfortaa font, south-gravity title text).
- **`app/httproute.yaml`** — `posterizarr.vaderrp.com` behind `oidc-auth` on the public gateway, with homepage annotations.
- **`app/vpa.yaml`** — recommendation-only VPA (ImageMagick runs burst hard; 4Gi memory limit).

## ⚠️ Action required before this can start

Add three fields to the existing media Bitwarden item (`82de75a5…`, the one with `plextoken`/`tmdbapikey`):

1. **`tmdbtoken`** — the TMDb **API Read Access Token** (the long v4 bearer token from [TMDb API settings](https://www.themoviedb.org/settings/api)) — this is *not* the v3 `tmdbapikey` Kometa uses.
2. **`tvdbapi`** — a [TVDB API key](https://thetvdb.com/api-information) (free).
3. **`fanarttvapikey`** — a [Fanart.tv personal API key](https://fanart.tv/get-an-api-key/) (free).

Until these exist the ExternalSecret won't sync and the pod won't start.

## Notes

- First run generates assets for the whole library — expect it to take a long time and hammer TMDb/Fanart a bit; subsequent runs only process new/changed items.
- `LibstoExclude` is empty — all Plex libraries are processed. Add library names there to exclude any.
- Kometa asset-directory integration (Kometa applying Posterizarr's generated files via `asset_directory`) is possible later but needs a shared volume (e.g. NFS) between the two — direct Plex upload sidesteps that for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR)_