### PR TITLE
refactor(media): make posterizarr config.json a seed, UI-owned after

### DIFF
--- a/kubernetes/apps/media/posterizarr/app/external-secret.yaml
+++ b/kubernetes/apps/media/posterizarr/app/external-secret.yaml
@@ -14,9 +14,11 @@ spec:
       engineVersion: v2
       data:
         # Full Posterizarr config - rendered here because it embeds API tokens.
-        # An initContainer copies it onto the /config PVC at pod start, so git
-        # stays the source of truth across restarts while the app can still
-        # write to the file at runtime.
+        # SEED ONLY: the initContainer copies this onto the /config PVC just
+        # when no config.json exists yet (fresh PVC / disaster recovery). The
+        # web UI owns the file afterwards - runtime changes are made there and
+        # are never overwritten. Keep notable UI changes mirrored here so a
+        # future re-seed doesn't regress them.
         # Inspired by bullmoose20's community config:
         # https://github.com/Kometa-Team/Community-Configs/blob/master/bullmoose20/posterizarr/bullmoose20config.json
         config.json: |
@@ -33,7 +35,7 @@ spec:
               "PreferredSeasonLanguageOrder": ["xx"],
               "PreferredBackgroundLanguageOrder": ["xx"],
               "PreferredTCLanguageOrder": ["xx"],
-              "LogoLanguageOrder": ["en"],
+              "LogoLanguageOrder": ["en", "fi"],
               "tmdb_vote_sorting": "vote_average",
               "WidthHeightFilter": "false",
               "PosterMinWidth": "2000",
@@ -42,10 +44,10 @@ spec:
               "BgTcMinHeight": "2160"
             },
             "PlexPart": {
-              "LibstoExclude": [],
+              "LibstoExclude": ["Muskarit", "Photos"],
               "PlexUrl": "https://plex.vaderrp.com",
               "UsePlex": "true",
-              "UploadExistingAssets": "false"
+              "UploadExistingAssets": "true"
             },
             "JellyfinPart": {
               "LibstoExclude": [],

--- a/kubernetes/apps/media/posterizarr/app/external-secret.yaml
+++ b/kubernetes/apps/media/posterizarr/app/external-secret.yaml
@@ -19,6 +19,10 @@ spec:
         # web UI owns the file afterwards - runtime changes are made there and
         # are never overwritten. Keep notable UI changes mirrored here so a
         # future re-seed doesn't regress them.
+        # Upload semantics: PlexUpload ("Enable Plex Upload") ALWAYS uploads
+        # generated art; UploadExistingAssets only uploads when Plex's current
+        # art lacks Posterizarr/Kometa/TCM EXIF markers. Both stay enabled so
+        # resets/regenerations actually replace already-stamped art in Plex.
         # Inspired by bullmoose20's community config:
         # https://github.com/Kometa-Team/Community-Configs/blob/master/bullmoose20/posterizarr/bullmoose20config.json
         config.json: |

--- a/kubernetes/apps/media/posterizarr/app/values.yaml
+++ b/kubernetes/apps/media/posterizarr/app/values.yaml
@@ -13,7 +13,9 @@ controllers:
         command:
           - sh
           - -c
-          - cp /overlays/*.png /config/
+          # config.json is UI-owned: seed it from the secret only on a fresh
+          # /config PVC, never overwrite (the web UI writes changes back to it)
+          - '[ -f /config/config.json ] || cp /secret/config.json /config/config.json; cp /overlays/*.png /config/'
     containers:
       app:
         image:


### PR DESCRIPTION
## Summary

Resolves the config-ownership conflict: Posterizarr's web UI writes settings back to `config.json`, so the original overwrite-on-start initContainer clobbered UI changes on every pod restart. The copy was already dropped on main (`60fb77d`); this formalizes the model as **seed-only**:

```sh
[ -f /config/config.json ] || cp /secret/config.json /config/config.json; cp /overlays/*.png /config/
```

- **Existing PVC**: config.json is never touched — the UI owns it entirely.
- **Fresh PVC** (disaster recovery, volume loss): the rendered config with all four API tokens is seeded automatically, so the app still bootstraps hands-off instead of coming up unconfigured.
- Overlay PNGs are still copied unconditionally (static assets).

Also mirrors the UI-made settings into the seed template so a future re-seed doesn't regress them: `LibstoExclude: ["Muskarit", "Photos"]`, `UploadExistingAssets: "true"`, `LogoLanguageOrder: ["en", "fi"]`. The ExternalSecret comment now documents the seed-only contract.

## Note

The live pod still has `"SeasonTCText": "true"` from earlier experimentation — since git no longer overwrites the file, fix it in the web UI (set the field to `Season`; it's the literal word printed on title cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR)_