### PR TITLE
feat(media): share posterizarr assets with kometa over NFS

### DIFF
--- a/kubernetes/apps/media/kometa/app/config.yaml
+++ b/kubernetes/apps/media/kometa/app/config.yaml
@@ -10,6 +10,10 @@
 libraries:
   Movies:
     remove_overlays: false
+    settings:
+      # Posterizarr-generated assets (shared NFS mount) as overlay base
+      asset_directory: /assets/Movies
+      prioritize_assets: true
     collection_files:
       # Academy Awards (Oscars) collections
       - default: oscars
@@ -51,8 +55,14 @@ libraries:
       # Ratings feeding the ratings overlay
       mass_critic_rating_update: imdb
       mass_audience_rating_update: tmdb
+      # Apply Posterizarr assets to every item
+      assets_for_all: true
   TV Shows:
     remove_overlays: false
+    settings:
+      # Posterizarr-generated assets (shared NFS mount) as overlay base
+      asset_directory: /assets/TV Shows
+      prioritize_assets: true
     collection_files:
       # IMDb charts (Popular, Top 250, Lowest Rated)
       - default: imdb
@@ -102,6 +112,8 @@ libraries:
       # Episode ratings feeding the episode-level ratings overlay
       mass_episode_critic_rating_update: imdb
       mass_episode_audience_rating_update: tmdb
+      # Apply Posterizarr assets to every item
+      assets_for_all: true
 
 settings:
   cache: true

--- a/kubernetes/apps/media/kometa/app/values.yaml
+++ b/kubernetes/apps/media/kometa/app/values.yaml
@@ -61,6 +61,15 @@ persistence:
     existingClaim: kometa
     globalMounts:
       - path: /config
+  # Posterizarr's generated assets (shared NFS) — used as overlay base via
+  # per-library asset_directory + prioritize_assets in config.yaml
+  assets:
+    type: nfs
+    server: 192.168.0.221
+    path: /mnt/Nakkiallas/Public/posterizarr
+    globalMounts:
+      - path: /assets
+        readOnly: true
   config-file:
     type: configMap
     name: kometa-config

--- a/kubernetes/apps/media/posterizarr/app/values.yaml
+++ b/kubernetes/apps/media/posterizarr/app/values.yaml
@@ -93,13 +93,27 @@ persistence:
       posterizarr:
         copy-config:
           - path: /overlays
+  # Shared with kometa (asset_directory) so overlays are composited from the
+  # generated assets directly instead of round-tripping art through Plex
   assets:
+    type: nfs
+    server: 192.168.0.221
+    path: /mnt/Nakkiallas/Public/posterizarr
+    advancedMounts:
+      posterizarr:
+        app:
+          - path: /assets
+  # Old local-path assets PVC, kept mounted read-only for one-time migration:
+  #   kubectl -n media exec deploy/posterizarr -- sh -c 'cp -a /assets-old/. /assets/'
+  # Remove this mount and pvc.yaml afterwards.
+  assets-old:
     type: persistentVolumeClaim
     existingClaim: posterizarr-assets
     advancedMounts:
       posterizarr:
         app:
-          - path: /assets
+          - path: /assets-old
+            readOnly: true
   assetsbackup:
     type: emptyDir
     advancedMounts:


### PR DESCRIPTION
## Summary

Implements Posterizarr's [Kometa integration](https://fscorrupt.github.io/posterizarr/kometaintegration) mode: instead of Kometa downloading current art from Plex, compositing overlays, and re-uploading, it now reads Posterizarr's generated assets directly from a shared volume and uses them as the overlay base.

## Why NFS

The old `posterizarr-assets` PVC is `local-path` (RWO, node-pinned) and the Kometa CronJob can schedule on any node. The cluster's only other storage class, `tns-iscsi`, is filesystem-mode iSCSI (`fsType: ext4`) — RWX on it would mean two nodes mounting the same ext4, which corrupts. NFS from the NAS is the repo's established multi-reader pattern (radarr/sonarr/bazarr).

## Changes

- **Shared asset store**: `192.168.0.221:/mnt/Nakkiallas/Public/posterizarr` (pre-created on the NAS), mounted at `/assets` by both Posterizarr (rw) and the Kometa CronJob (ro). Posterizarr's `AssetPath` stays `/assets`, so no config.json change is needed.
- **Kometa config**: per-library `settings` with `asset_directory: /assets/<Library>` + `prioritize_assets: true`, and `assets_for_all: true` in both libraries' operations.
- **Migration**: the old PVC stays mounted read-only at `/assets-old`; after merge run
  `kubectl -n media exec deploy/posterizarr -- sh -c 'cp -a /assets-old/. /assets/'`
  A follow-up PR removes the `assets-old` mount and `pvc.yaml`.

## Post-merge notes

- Merging restarts the Posterizarr deployment — if a run/reset is in progress it gets killed; re-trigger it after the copy.
- Once satisfied that Kometa is applying assets, `PlexUpload` can be turned off in the Posterizarr UI (Kometa becomes the sole uploader, ending the daily double-upload) — mirror that in the seed template when done.
- The NFS asset store is not VolSync-backed (same as before: regenerable data, and the NAS has its own redundancy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR)_