### PR TITLE
chore(media): mirror PlexUpload=false into posterizarr seed template

### DIFF
--- a/kubernetes/apps/media/posterizarr/app/external-secret.yaml
+++ b/kubernetes/apps/media/posterizarr/app/external-secret.yaml
@@ -21,8 +21,10 @@ spec:
         # future re-seed doesn't regress them.
         # Upload semantics: PlexUpload ("Enable Plex Upload") ALWAYS uploads
         # generated art; UploadExistingAssets only uploads when Plex's current
-        # art lacks Posterizarr/Kometa/TCM EXIF markers. Both stay enabled so
-        # resets/regenerations actually replace already-stamped art in Plex.
+        # art lacks Posterizarr/Kometa/TCM EXIF markers. PlexUpload is OFF:
+        # kometa applies the assets (shared NFS asset_directory) with its
+        # overlays and is the sole uploader. Re-enable temporarily in the UI
+        # for manual resets that must push art without waiting for kometa.
         # Inspired by bullmoose20's community config:
         # https://github.com/Kometa-Team/Community-Configs/blob/master/bullmoose20/posterizarr/bullmoose20config.json
         config.json: |
@@ -110,7 +112,7 @@ spec:
               "NewLineOnSpecificWords": "false",
               "NewLineWords": {},
               "SymbolsToKeepOnNewLine": [],
-              "PlexUpload": "true",
+              "PlexUpload": "false",
               "ForceRunningDeletion": "false",
               "SkipAddText": "false",
               "SkipAddTextAndBorder": "false",


### PR DESCRIPTION
## Summary

Final piece of the Posterizarr↔Kometa asset integration (#1592, #1593): `PlexUpload` has been turned off in the live (UI-owned) config — Kometa now applies the shared NFS assets with its overlays and is the sole uploader to Plex. This mirrors that into the git seed template so a fresh-PVC bootstrap comes up matching the live setup, and updates the flag-semantics comment accordingly (including the note that `PlexUpload` can be re-enabled temporarily in the UI for manual resets that shouldn't wait for Kometa's next run).

`UploadExistingAssets` stays `true` — it's EXIF-gated, so it only fills art that no managed tool has stamped yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR)_