### PR TITLE
feat: add LubeLogger, ntfy, Healthchecks, and Paperless-ngx

### DIFF
--- a/kubernetes/apps/observability/healthchecks/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/healthchecks/app/helmrelease.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: healthchecks
+  namespace: observability
+spec:
+  interval: 15m
+  chartRef:
+    kind: OCIRepository
+    name: healthchecks
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      healthchecks:
+        containers:
+          app:
+            image:
+              repository: docker.io/healthchecks/healthchecks
+              tag: v4.3@sha256:cd7bcd94350818b3944f82eb5995f48bdeab8c8627977578a569ffa73f56f56f
+            env:
+              TZ: Europe/Helsinki
+              SITE_ROOT: https://healthchecks.vaderrp.com
+              SITE_NAME: Healthchecks
+              ALLOWED_HOSTS: healthchecks.vaderrp.com
+              DB: sqlite
+              DB_NAME: /data/hc.sqlite
+              REGISTRATION_OPEN: "False"
+              DEBUG: "False"
+            envFrom:
+              - secretRef:
+                  name: healthchecks-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8000
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: {type: RuntimeDefault}
+    service:
+      app:
+        controller: healthchecks
+        ports:
+          http:
+            port: *port
+    persistence:
+      data:
+        existingClaim: healthchecks
+        globalMounts:
+          - path: /data
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/observability/healthchecks/app/httproute.yaml
+++ b/kubernetes/apps/observability/healthchecks/app/httproute.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: healthchecks
+  namespace: observability
+  labels:
+    route.scope: internal
+  annotations:
+    external-dns.alpha.kubernetes.io/public: "false"
+    gatus.home-operations.com/enabled: "true"
+    gatus.home-operations.com/endpoint: |
+      group: Observability
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Observability
+    gethomepage.dev/name: Healthchecks
+    gethomepage.dev/icon: healthchecks.png
+    gethomepage.dev/href: https://healthchecks.vaderrp.com
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=healthchecks
+spec:
+  parentRefs:
+    - name: gateway-internal
+      namespace: network
+  hostnames: ["healthchecks.vaderrp.com"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: healthchecks
+          port: 8000

--- a/kubernetes/apps/observability/healthchecks/app/kustomization.yaml
+++ b/kubernetes/apps/observability/healthchecks/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - httproute.yaml
+  - ocirepository.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/observability/healthchecks/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/healthchecks/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: healthchecks
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/healthchecks/app/secret.sops.yaml
+++ b/kubernetes/apps/observability/healthchecks/app/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: healthchecks-secret
+  namespace: observability
+stringData:
+  SECRET_KEY: ENC[AES256_GCM,data:fmgElF34w8KcBwi+lapMDIhlNRrnaGwzSL1p58B5a4H2+2LtgJuOOflfHC1dIg6/1RU=,iv:300tYEKeENyLxsT36bJiZYcfQiTjPDAK6ZJrVBsMw38=,tag:ZHONSSye43AvzpgAjcDKtQ==,type:str]
+sops:
+  age:
+    - recipient: age18hklnzlqlz0y7tf8gzeh2slv8vxnlyvjcn7e38xsd744s3t9hf0su4lwpx
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBySnV0dk56KzhtNUVNK0JG
+        THUzUUNpelJVQlFFTjBFS3N1QjBnMnlMNVJNCkwwTFk0QzRTM2lUbEVuR2dVOGEw
+        MGFYRmZES09OQW9sVCtWWHBVSGZ6bTgKLS0tIHc2a0J0LzJaU0s1Rjl1YkFRSVky
+        aFZBVEZSZno4Umh2czdicUczRlArencKdv/CPJ2Rt/rZEZVq5t5/mpa1Nid0Px60
+        /fDVomIIxBX1CWZNbSulx0zEpYda3jXsB0plI+XjuF66ZPvREk0IGg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-25T09:59:45Z"
+  mac: ENC[AES256_GCM,data:XAVjtTkeV4sfi00CgAsaMngDkueSNSviJzOCTi2Cbp84dduvQcrECmXUazWPipjtgpPTp1hVS7aIGlgyhTISc2bjvLu0UNHhFgLROea0dqh66vZPYyK8Ajds9YCboAmjOzfPHrViXsdzPPsmyNYKI2Qje1+KAdsafc8z32AWBAY=,iv:O4H/nU08W2/IqfldN/as24W9LFbAGWX3zsJgVYc0r/M=,tag:sB2BkZ1XcNDz8KQWGPDGaw==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.11.0

--- a/kubernetes/apps/observability/healthchecks/ks.yaml
+++ b/kubernetes/apps/observability/healthchecks/ks.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: healthchecks
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: healthchecks
+  path: "./kubernetes/apps/observability/healthchecks/app"
+  prune: true
+  dependsOn:
+    - name: volsync
+      namespace: storage
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # Default false for speed, enable for critical
+  components:
+    - ../../../../components/volsync-kopia
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: healthchecks
+      VOLSYNC_COPYMETHOD: Direct
+      VOLSYNC_CAPACITY: 2Gi
+      VOLSYNC_STORAGECLASS: local-path
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
   - ./gatus/ks.yaml
   - ./goldilocks/ks.yaml
   - ./grafana/ks.yaml
+  - ./healthchecks/ks.yaml
+  - ./ntfy/ks.yaml
   - ./kromgo/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml

--- a/kubernetes/apps/observability/ntfy/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/ntfy/app/helmrelease.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ntfy
+  namespace: observability
+spec:
+  interval: 15m
+  chartRef:
+    kind: OCIRepository
+    name: ntfy
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      ntfy:
+        containers:
+          app:
+            image:
+              repository: docker.io/binwiederhier/ntfy
+              tag: v2.26.3@sha256:081b53dbb20674fcfe05fdb4eb8af9036a2645ef979543d16f7f80803af467b1
+            args: ["serve"]
+            env:
+              TZ: Europe/Helsinki
+              NTFY_BASE_URL: https://ntfy.vaderrp.com
+              NTFY_LISTEN_HTTP: ":8080"
+              NTFY_BEHIND_PROXY: "true"
+              NTFY_CACHE_FILE: /var/cache/ntfy/cache.db
+              NTFY_ATTACHMENT_CACHE_DIR: /var/cache/ntfy/attachments
+              NTFY_AUTH_FILE: /var/lib/ntfy/auth.db
+              NTFY_AUTH_DEFAULT_ACCESS: deny-all
+              NTFY_ENABLE_LOGIN: "true"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /v1/health
+                    port: &port 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: {type: RuntimeDefault}
+    service:
+      app:
+        controller: ntfy
+        ports:
+          http:
+            port: *port
+    persistence:
+      data:
+        existingClaim: ntfy
+        globalMounts:
+          - path: /var/cache/ntfy
+            subPath: cache
+          - path: /var/lib/ntfy
+            subPath: auth

--- a/kubernetes/apps/observability/ntfy/app/httproute.yaml
+++ b/kubernetes/apps/observability/ntfy/app/httproute.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ntfy
+  namespace: observability
+  labels:
+    route.scope: external
+  annotations:
+    external-dns.alpha.kubernetes.io/target: external.vaderrp.com
+    gatus.home-operations.com/enabled: "true"
+    gatus.home-operations.com/endpoint: |
+      group: Observability
+      url: "https://ntfy.vaderrp.com/v1/health"
+      conditions:
+        - "[STATUS] == 200"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Observability
+    gethomepage.dev/name: ntfy
+    gethomepage.dev/icon: ntfy.png
+    gethomepage.dev/href: https://ntfy.vaderrp.com
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=ntfy
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-public
+      namespace: network
+  hostnames:
+    - ntfy.vaderrp.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: traefik-warp
+      backendRefs:
+        - name: ntfy
+          port: 8080

--- a/kubernetes/apps/observability/ntfy/app/kustomization.yaml
+++ b/kubernetes/apps/observability/ntfy/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - httproute.yaml
+  - ocirepository.yaml

--- a/kubernetes/apps/observability/ntfy/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/ntfy/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ntfy
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/ntfy/ks.yaml
+++ b/kubernetes/apps/observability/ntfy/ks.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ntfy
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+  targetNamespace: observability
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: ntfy
+  path: "./kubernetes/apps/observability/ntfy/app"
+  prune: true
+  dependsOn:
+    - name: volsync
+      namespace: storage
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # Default false for speed, enable for critical
+  components:
+    - ../../../../components/volsync-kopia
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: ntfy
+      VOLSYNC_COPYMETHOD: Direct
+      VOLSYNC_CAPACITY: 2Gi
+      VOLSYNC_STORAGECLASS: local-path
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./log-aggregator/ks.yaml
   - ./lubelogger/ks.yaml
   - ./n8n/ks.yaml
+  - ./paperless/ks.yaml
   - ./parsedmarc/ks.yaml
   - ./tainer/ks.yaml
   - ./trilium/ks.yaml

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./birdnet-go/ks.yaml
   - ./headlamp/ks.yaml
   - ./log-aggregator/ks.yaml
+  - ./lubelogger/ks.yaml
   - ./n8n/ks.yaml
   - ./parsedmarc/ks.yaml
   - ./tainer/ks.yaml

--- a/kubernetes/apps/tools/lubelogger/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/lubelogger/app/helmrelease.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: lubelogger
+  namespace: tools
+spec:
+  interval: 15m
+  chartRef:
+    kind: OCIRepository
+    name: lubelogger
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      lubelogger:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/hargata/lubelogger
+              tag: v1.7.0@sha256:01bdb486af71e641c3ae41499e0412a21f2e04fa31b25c5c6531b42c112938e5
+            env:
+              TZ: Europe/Helsinki
+              ASPNETCORE_HTTP_PORTS: &port 8080
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        # Image runs as root: writes LiteDB + uploads to /App/data and
+        # ASP.NET data-protection keys to /root/.aspnet
+        seccompProfile: {type: RuntimeDefault}
+    service:
+      app:
+        controller: lubelogger
+        ports:
+          http:
+            port: *port
+    persistence:
+      data:
+        existingClaim: lubelogger
+        globalMounts:
+          - path: /App/data
+            subPath: data
+          - path: /root/.aspnet/DataProtection-Keys
+            subPath: keys
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/tools/lubelogger/app/httproute.yaml
+++ b/kubernetes/apps/tools/lubelogger/app/httproute.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: lubelogger
+  namespace: tools
+  labels:
+    route.scope: internal
+  annotations:
+    external-dns.alpha.kubernetes.io/public: "false"
+    gatus.home-operations.com/enabled: "true"
+    gatus.home-operations.com/endpoint: |
+      group: Tools
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: LubeLogger
+    gethomepage.dev/icon: lubelogger.png
+    gethomepage.dev/href: https://lubelogger.vaderrp.com
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=lubelogger
+spec:
+  parentRefs:
+    - name: gateway-internal
+      namespace: network
+  hostnames: ["lubelogger.vaderrp.com"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: lubelogger
+          port: 8080

--- a/kubernetes/apps/tools/lubelogger/app/kustomization.yaml
+++ b/kubernetes/apps/tools/lubelogger/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - httproute.yaml
+  - ocirepository.yaml

--- a/kubernetes/apps/tools/lubelogger/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/lubelogger/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: lubelogger
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/lubelogger/ks.yaml
+++ b/kubernetes/apps/tools/lubelogger/ks.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: lubelogger
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+  targetNamespace: tools
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: lubelogger
+  path: "./kubernetes/apps/tools/lubelogger/app"
+  prune: true
+  dependsOn:
+    - name: volsync
+      namespace: storage
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # Default false for speed, enable for critical
+  components:
+    - ../../../../components/volsync-kopia
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: lubelogger
+      VOLSYNC_COPYMETHOD: Direct
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_STORAGECLASS: local-path
+      VOLSYNC_PUID: "0"
+      VOLSYNC_PGID: "0"

--- a/kubernetes/apps/tools/paperless/app/external-secret.yaml
+++ b/kubernetes/apps/tools/paperless/app/external-secret.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: paperless-external-secret
+  namespace: tools
+spec:
+  refreshInterval: 1h
+  target:
+    name: paperless-external-secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      data:
+        # postgres-init superuser (same Vaultwarden item as other CNPG apps)
+        INIT_POSTGRES_SUPER_PASS: "{{ .super_password }}"
+        # Dragonfly requires auth (same Vaultwarden item as authentik)
+        PAPERLESS_REDIS: "redis://:{{ .dragonfly_password }}@dragonfly.database.svc.cluster.local:6379"
+  data:
+    - secretKey: super_password
+      sourceRef:
+        storeRef:
+          name: bitwarden-login
+          kind: ClusterSecretStore
+      remoteRef:
+        key: ed32aa71-d74b-43bc-a467-aaa2569f532f
+        property: password
+    - secretKey: dragonfly_password
+      sourceRef:
+        storeRef:
+          name: bitwarden-login
+          kind: ClusterSecretStore
+      remoteRef:
+        key: 00bfab9a-6bcf-4598-aaf6-2a65746691db
+        property: password

--- a/kubernetes/apps/tools/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/paperless/app/helmrelease.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: paperless
+  namespace: tools
+spec:
+  interval: 15m
+  chartRef:
+    kind: OCIRepository
+    name: paperless
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      paperless:
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18.4"
+            envFrom: &envFrom
+              - secretRef:
+                  name: paperless-secret
+              - secretRef:
+                  name: paperless-external-secret
+        containers:
+          app:
+            image:
+              repository: ghcr.io/paperless-ngx/paperless-ngx
+              tag: 3.0.2@sha256:fef384c955d2ec2acf1bd0882ffc195ecc170266c803dfe28b79df6deabb3569
+            env:
+              PAPERLESS_URL: https://paperless.vaderrp.com
+              PAPERLESS_TIME_ZONE: Europe/Helsinki
+              PAPERLESS_DBHOST: postgres17-rw.database.svc.cluster.local.
+              PAPERLESS_DBNAME: paperless
+              PAPERLESS_OCR_LANGUAGE: fin+eng
+              PAPERLESS_OCR_LANGUAGES: fin
+              PAPERLESS_TASK_WORKERS: "2"
+              USERMAP_UID: "1000"
+              USERMAP_GID: "1000"
+            envFrom: *envFrom
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8000
+                  initialDelaySeconds: 60
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1Gi
+              limits:
+                memory: 3Gi
+    service:
+      app:
+        controller: paperless
+        ports:
+          http:
+            port: *port
+    persistence:
+      data:
+        existingClaim: paperless
+        globalMounts:
+          - path: /usr/src/paperless/data
+            subPath: data
+          - path: /usr/src/paperless/media
+            subPath: media
+          - path: /usr/src/paperless/export
+            subPath: export
+          - path: /usr/src/paperless/consume
+            subPath: consume
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/tools/paperless/app/httproute.yaml
+++ b/kubernetes/apps/tools/paperless/app/httproute.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: paperless
+  namespace: tools
+  labels:
+    route.scope: internal
+  annotations:
+    external-dns.alpha.kubernetes.io/public: "false"
+    gatus.home-operations.com/enabled: "true"
+    gatus.home-operations.com/endpoint: |
+      group: Tools
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Paperless-ngx
+    gethomepage.dev/icon: paperless-ngx.png
+    gethomepage.dev/href: https://paperless.vaderrp.com
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=paperless
+spec:
+  parentRefs:
+    - name: gateway-internal
+      namespace: network
+  hostnames: ["paperless.vaderrp.com"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: paperless
+          port: 8000

--- a/kubernetes/apps/tools/paperless/app/kustomization.yaml
+++ b/kubernetes/apps/tools/paperless/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml
+  - helmrelease.yaml
+  - httproute.yaml
+  - ocirepository.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/tools/paperless/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/paperless/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: paperless
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/paperless/app/secret.sops.yaml
+++ b/kubernetes/apps/tools/paperless/app/secret.sops.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: paperless-secret
+  namespace: tools
+stringData:
+  PAPERLESS_SECRET_KEY: ENC[AES256_GCM,data:sPkdiGOEapHjzSp7hNx7NDSb/WFJsspqxLjgWjQ60vageGXmrvgATtPvjjqvXXAsVJQ=,iv:izMdHz1UPgDjUTHcwn8gSyElH4G3hXBIYhK0fRKPJIQ=,tag:E3v0ymnmIDmi5j8MtXK4VA==,type:str]
+  PAPERLESS_DBUSER: ENC[AES256_GCM,data:lNvW2sfHc6h2,iv:iV/gUuH9+nUiiPHTG0zxIFkARBAnc2O+BbtW2yYPJ0E=,tag:qOqgecnuN1sGrRgtMGwHNQ==,type:str]
+  PAPERLESS_DBPASS: ENC[AES256_GCM,data:VjGbpT6emvmrKNRFxAbzutOaNdNlcg+hJxoWYqBV/LA=,iv:fF1a9vyjuKC/iU9BbHAymTxS2bILQVw83MYcXHgMupA=,tag:sCc8DCYEGF+9FwtciYp4Fg==,type:str]
+  PAPERLESS_ADMIN_USER: ENC[AES256_GCM,data:GwDdShI=,iv:Pw1jPm1k9le0mINdn+dYWdVjBcNnQ5RoEojCVchXbvM=,tag:/kTKvHIIuVjDBcfjp+FqfA==,type:str]
+  PAPERLESS_ADMIN_PASSWORD: ENC[AES256_GCM,data:RvTbW+mBWSYlbe1vCPP1QcgGAqw=,iv:RxfkeR2R3LqJMpz9Yueg2RBzQAzwOo2udqOqHdr2C6Q=,tag:mc3liUN1H/DerKP9Ta0Qag==,type:str]
+  INIT_POSTGRES_HOST: ENC[AES256_GCM,data:S2dFlGW3xCv9zsF0y0kw2XiYVGVQ5aithaISJffB4SbWmsO36B8tiGk=,iv:+3aDT0A3bC+L5hq1tiTGkmmiPVcrerMFp/tyomwcgiY=,tag:bu5w5bD6CYRUvoCcdWlSZw==,type:str]
+  INIT_POSTGRES_USER: ENC[AES256_GCM,data:O0ER4NmdXfr3,iv:NINMlAC3JBoCn6F2d0MWha9WMMIjMyxwwny7Z66iC0I=,tag:iCaa1+SCvglnDvTu9zGJDQ==,type:str]
+  INIT_POSTGRES_PASS: ENC[AES256_GCM,data:qwls8hvyGRADWGm7R5QG/s+lrKM9u/BnhbjSR6CbDGI=,iv:7/4suR3vpTX1S65Yy13VsFVaBfvGCrIpb4FnKGBQTcU=,tag:wA/P5gRmbG03RKx4sdfcvA==,type:str]
+  INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:fNq5ODHXGQH9,iv:VtPDVEI1S+CAPoIGC5xEG6duGe7Ar93UrEw10n/uis0=,tag:mHtBGEd2v9bJmqm7SST20w==,type:str]
+sops:
+  age:
+    - recipient: age18hklnzlqlz0y7tf8gzeh2slv8vxnlyvjcn7e38xsd744s3t9hf0su4lwpx
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaM2ppdUZwZWpVNGkyY3g4
+        bmhsQlZoU2cyQWN4a051Mkx1bW1vTHpRU2pFCk96OW0wZEpmYXc2VTFNamMvWjh0
+        cExYSmhDYkt2V2RWaWRsaHhhMU1JSUkKLS0tIDg2Y0Z6YTBpMWNOQlFnOVIwQXNZ
+        amk4M3NXTnJHaGZCTGx1WjFOeUdQMUEKwf6tUFchQUuCYQ5oxufpAvnaMpWkswZV
+        LSCdfn7oSN4sRjWw//IjMbt2XK5/w4DPdcr2oqrXDMGZgjwgTLyt6w==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-25T09:59:45Z"
+  mac: ENC[AES256_GCM,data:olBta1/kQvRPAj0NmypNjEhOpU7dULmcsJX3ldwFwx7ZVlcmV1IHdqkpA8lmzVgqlLAypwvd/+pZCxYfExudom5Im3K23lhjbxWD8d2rdaKY/Oha6RElyfFzG8koFsdM71qn5VnaAgJvl4A8EzpBQKw5RbwnODuzkDm0dRrOkUQ=,iv:y5O6MeudBWbeOZSNMIlUYtAudzg+p7E8dFlXZTPnCu0=,tag:+Gr2WerhWJuVl6xGXDlsCA==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.11.0

--- a/kubernetes/apps/tools/paperless/ks.yaml
+++ b/kubernetes/apps/tools/paperless/ks.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: paperless
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+  targetNamespace: tools
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: paperless
+  path: "./kubernetes/apps/tools/paperless/app"
+  prune: true
+  dependsOn:
+    - name: volsync
+      namespace: storage
+    - name: cloudnative-pg
+      namespace: database
+    - name: dragonfly
+      namespace: database
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # Default false for speed, enable for critical
+  components:
+    - ../../../../components/volsync-kopia
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: paperless
+      VOLSYNC_COPYMETHOD: Direct
+      VOLSYNC_CAPACITY: 20Gi
+      VOLSYNC_STORAGECLASS: local-path
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"


### PR DESCRIPTION
Adds four apps picked from an [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted) sweep against the current stack. One commit per app so any can be dropped independently.

## LubeLogger (`tools`) — v1.7.0
Vehicle maintenance and fuel-mileage tracker.
- bjw-s app-template 4.6.2, image pinned by digest, LiteDB + ASP.NET data-protection keys on a 5Gi VolSync PVC via subPaths
- Internal-only route at `lubelogger.vaderrp.com`; built-in auth for now (OIDC via authentik is a possible follow-up)
- LiteDB keeps the footprint small; can move to CNPG Postgres via `POSTGRES_CONNECTION` later

## ntfy (`observability`) — v2.26.3
Push notification server (Gatus, Tautulli, n8n, Healthchecks, alertmanager can all publish to it).
- **Exposed externally** via cloudflared so mobile push works off-LAN — but `NTFY_AUTH_DEFAULT_ACCESS: deny-all` with login enabled, so nothing is readable/writable until users are created (`kubectl exec ... -- ntfy user add --role=admin <name>`)
- Cache + auth DBs on a 2Gi VolSync PVC; hardened non-root, read-only rootfs

## Healthchecks (`observability`) — v4.3
Dead-man's-switch monitoring: complements Gatus ("is it up") with "did the cron/backup actually run" — VolSync/kopia jobs, Tautulli scripts, etc. Has a native ntfy integration.
- SQLite on a 2Gi VolSync PVC, SOPS-encrypted Django `SECRET_KEY`
- Registration closed; create the superuser once with `kubectl exec ... -- /opt/healthchecks/manage.py createsuperuser`
- Internal-only route at `healthchecks.vaderrp.com`

## Paperless-ngx (`tools`) — v3.0.2
Document scanning/OCR/archive.
- CNPG Postgres using the existing postgres-init pattern: app DB credentials generated and SOPS-encrypted; `INIT_POSTGRES_SUPER_PASS` and the Dragonfly password reuse the **existing** Vaultwarden items already referenced by n8n and authentik — no new secrets to create manually
- Redis via Dragonfly (password templated into `PAPERLESS_REDIS` by ExternalSecret)
- OCR languages `fin+eng` (`fin` pack installed at startup), admin user bootstrapped via SOPS-encrypted `PAPERLESS_ADMIN_*`
- `data`/`media`/`consume`/`export` on a 20Gi VolSync PVC; internal-only route at `paperless.vaderrp.com`
- Gotenberg/Tika sidecars (office-document support) left as a follow-up

## Validation
- `kustomize build` passes for each app and for the `tools`/`observability` namespace overlays
- `yamllint` (repo config) passes on all new files
- Both `secret.sops.yaml` files encrypted against the repo's age recipient

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvuQasuBxgcEaYfGpPJR8n