### PR TITLE
fix(media): remove invalid kometa content-rating source, fix asset dir

### DIFF
--- a/kubernetes/apps/media/kometa/app/config.yaml
+++ b/kubernetes/apps/media/kometa/app/config.yaml
@@ -49,7 +49,9 @@ libraries:
     operations:
       # Fix/normalize metadata from TMDb
       mass_genre_update: tmdb
-      mass_content_rating_update: tmdb
+      # NOTE: tmdb is NOT a valid content-rating source (kometa treats unknown
+      # values as literals and mass-writes the string). Valid sources like
+      # omdb/mdb_* need their own API keys - left disabled.
       mass_originally_available_update: tmdb
       mass_studio_update: tmdb
       # Ratings feeding the ratings overlay
@@ -106,7 +108,9 @@ libraries:
           font_color: '#FFFFFF00'
     operations:
       mass_genre_update: tmdb
-      mass_content_rating_update: tmdb
+      # NOTE: tmdb is NOT a valid content-rating source (kometa treats unknown
+      # values as literals and mass-writes the string). Valid sources like
+      # omdb/mdb_* need their own API keys - left disabled.
       mass_originally_available_update: tmdb
       mass_studio_update: tmdb
       # Episode ratings feeding the episode-level ratings overlay
@@ -118,7 +122,7 @@ libraries:
 settings:
   cache: true
   cache_expiration: 60
-  asset_directory: /config/assets
+  asset_directory: /assets
   asset_folders: true
   show_missing: false
   show_unmanaged: true


### PR DESCRIPTION
## Summary

Root-causes the "5-minute Kometa runs, no overlays anywhere" problem from the meta.log of the last scheduled run. Overlays run **last** (`operations → metadata → collections → overlays`), and both libraries were crashing during operations, so the overlay phase never executed:

## Movies: invalid operation source (config bug — this PR)

`mass_content_rating_update: tmdb` is not a valid content-rating source (`tmdb` works for genre/date/studio, not ratings). Kometa treats unknown values as **custom literals**, so it queued "set content rating to the string `tmdb`" for all 1952 movies, batched them into a single Plex API call, and died:

```
plexapi.exceptions.BadRequest: (414) request_uri_too_large; .../all?contentRating.value=tmdb&id=<1952 ids>
```

→ Movies library aborted before overlays. The operation is removed; proper sources (`omdb`, `mdb_*`) need their own API keys and can be added later if wanted. (The 414 also means the bogus literal was never actually written to Plex.)

Also: global `asset_directory` now points at the mounted `/assets` share instead of the nonexistent `/config/assets` (per-library overrides already did), silencing the `Path does not exist` warning.

## TV Shows: corrupted TMDb episode cache (manual step, not in this PR)

```
sqlite3.IntegrityError: UNIQUE constraint failed: tmdb_episode_data2.episode_id, tmdb_episode_data2.language
```

Kometa's SQLite cache on the config PVC has conflicting rows (likely from the earlier OOM-killed runs dying mid-write). Fix by deleting the cache file so it rebuilds — via `just kube browse-pvc media kometa`, remove `config.cache` (the SQLite file next to the config) — then trigger a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR)_