### PR TITLE
feat(media): wire Common Sense content ratings via MDBList

### DIFF
--- a/kubernetes/apps/media/kometa/app/config.yaml
+++ b/kubernetes/apps/media/kometa/app/config.yaml
@@ -49,9 +49,10 @@ libraries:
     operations:
       # Fix/normalize metadata from TMDb
       mass_genre_update: tmdb
-      # NOTE: tmdb is NOT a valid content-rating source (kometa treats unknown
-      # values as literals and mass-writes the string). Valid sources like
-      # omdb/mdb_* need their own API keys - left disabled.
+      # Common Sense age ratings via MDBList (feeds the commonsense overlay
+      # and content_rating_cs collections). NOTE: tmdb is NOT a valid source
+      # here - kometa mass-writes unknown values as literal strings.
+      mass_content_rating_update: mdb_commonsense
       mass_originally_available_update: tmdb
       mass_studio_update: tmdb
       # Ratings feeding the ratings overlay
@@ -108,9 +109,10 @@ libraries:
           font_color: '#FFFFFF00'
     operations:
       mass_genre_update: tmdb
-      # NOTE: tmdb is NOT a valid content-rating source (kometa treats unknown
-      # values as literals and mass-writes the string). Valid sources like
-      # omdb/mdb_* need their own API keys - left disabled.
+      # Common Sense age ratings via MDBList (feeds the commonsense overlay
+      # and content_rating_cs collections). NOTE: tmdb is NOT a valid source
+      # here - kometa mass-writes unknown values as literal strings.
+      mass_content_rating_update: mdb_commonsense
       mass_originally_available_update: tmdb
       mass_studio_update: tmdb
       # Episode ratings feeding the episode-level ratings overlay
@@ -142,6 +144,10 @@ plex:
   clean_bundles: false
   empty_trash: false
   optimize: false
+
+mdblist:
+  apikey: <<mdblistapikey>>
+  cache_expiration: 60
 
 tmdb:
   apikey: <<tmdbapikey>>

--- a/kubernetes/apps/media/kometa/app/external-secret.yaml
+++ b/kubernetes/apps/media/kometa/app/external-secret.yaml
@@ -18,6 +18,7 @@ spec:
         # https://kometa.wiki/en/latest/kometa/environmental/
         KOMETA_PLEXTOKEN: "{{ .plextoken }}"
         KOMETA_TMDBAPIKEY: "{{ .tmdbapikey }}"
+        KOMETA_MDBLISTAPIKEY: "{{ .mdblistapikey }}"
         KOMETA_RADARRAPIKEY: "{{ .radarrapikey }}"
         KOMETA_SONARRAPIKEY: "{{ .sonarrapikey }}"
   data:
@@ -40,6 +41,16 @@ spec:
       remoteRef:
         key: 82de75a5-08e1-4f8c-82a3-1b45d067e78e
         property: tmdbapikey
+
+    # MDBList API Key (kometa item, mdblistapikey field) — Common Sense ratings
+    - secretKey: mdblistapikey
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        key: 82de75a5-08e1-4f8c-82a3-1b45d067e78e
+        property: mdblistapikey
 
     # Radarr API Key (same item as radarr's own external-secret)
     - secretKey: radarrapikey


### PR DESCRIPTION
## Summary

Completes the Common Sense integration that's been dormant since the kometa rollout: the `commonsense` overlay badges and `content_rating_cs` collections match on Common Sense–format content ratings, which nothing was populating (and the previous attempt with `tmdb` as the source was invalid — removed in #1598).

## Changes

- New top-level `mdblist` config section (`apikey` via the `<<mdblistapikey>>` Config Secret, 60-day cache expiration).
- `mass_content_rating_update: mdb_commonsense` restored to both libraries' operations — sets Plex content ratings to Common Sense age ratings from MDBList.
- ExternalSecret exposes `KOMETA_MDBLISTAPIKEY` from a new `mdblistapikey` field on the kometa Bitwarden item (`82de75a5…`).

## ⚠️ Before merge

Add the `mdblistapikey` field to the Bitwarden item with an API key from [mdblist.com/preferences](https://mdblist.com/preferences/) (free tier: 1,000 calls/day; Kometa caches responses so a full library pass fits comfortably after the first run).

## Notes

- Unlike the invalid-literal case from #1598, `mdb_commonsense` resolves per-item values, so batched Plex updates split across the ~18 distinct age ratings — no single mega-URL, so the 414 failure mode shouldn't reproduce.
- First run with this enabled will do an MDBList lookup per item; combined with the pending full overlay pass, expect a long run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR)_