### PR TITLE
feat(media): plumbing for posterizarr-triggered kometa runs

### DIFF
--- a/kubernetes/apps/media/kometa/app/config.yaml
+++ b/kubernetes/apps/media/kometa/app/config.yaml
@@ -37,8 +37,6 @@ libraries:
       - default: runtimes
       # Common Sense age rating badge
       - default: commonsense
-      # Award/chart ribbons (Oscars, IMDb Top 250, ...)
-      - default: ribbon
       # Languages spoken and subtitles with associated flags and two-digit lang codes
       - default: languages
       # Languages spoken and subtitles with associated flags and two-digit lang codes

--- a/kubernetes/apps/media/kometa/app/config.yaml
+++ b/kubernetes/apps/media/kometa/app/config.yaml
@@ -37,6 +37,8 @@ libraries:
       - default: runtimes
       # Common Sense age rating badge
       - default: commonsense
+      # Award/chart ribbons (Oscars, IMDb Top 250, ...)
+      - default: ribbon
       # Languages spoken and subtitles with associated flags and two-digit lang codes
       - default: languages
       # Languages spoken and subtitles with associated flags and two-digit lang codes

--- a/kubernetes/apps/media/kometa/app/kustomization.yaml
+++ b/kubernetes/apps/media/kometa/app/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ocirepository.yaml
   - helmrelease.yaml
   - external-secret.yaml
+  - rbac.yaml
   - vpa.yaml
 
 configMapGenerator:

--- a/kubernetes/apps/media/kometa/app/rbac.yaml
+++ b/kubernetes/apps/media/kometa/app/rbac.yaml
@@ -48,3 +48,31 @@ subjects:
   - kind: ServiceAccount
     name: kometa-trigger
     namespace: media
+---
+# Read-only job visibility for the kometa pod itself: the wait-for-turn
+# initContainer polls for other active kometa jobs so runs serialize instead
+# of overlapping. The `kometa` ServiceAccount is created by app-template
+# (serviceAccount block in values.yaml).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kometa-runner
+  namespace: media
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kometa-runner
+  namespace: media
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kometa-runner
+subjects:
+  - kind: ServiceAccount
+    name: kometa
+    namespace: media

--- a/kubernetes/apps/media/kometa/app/rbac.yaml
+++ b/kubernetes/apps/media/kometa/app/rbac.yaml
@@ -1,0 +1,50 @@
+---
+# Identity used by the n8n "poster pipeline" workflow to spawn ad-hoc kometa
+# Jobs when Posterizarr reports a completed run (Apprise webhook -> n8n ->
+# Kubernetes API). n8n authenticates with this ServiceAccount's bearer token
+# (see kometa-trigger-token below).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kometa-trigger
+  namespace: media
+---
+# Long-lived token for the ServiceAccount so it can be pasted into an n8n
+# Header Auth credential:
+#   kubectl -n media get secret kometa-trigger-token -o jsonpath='{.data.token}' | base64 -d
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kometa-trigger-token
+  namespace: media
+  annotations:
+    kubernetes.io/service-account.name: kometa-trigger
+type: kubernetes.io/service-account-token
+---
+# Just enough to read the kometa CronJob template and create/inspect Jobs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kometa-trigger
+  namespace: media
+rules:
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kometa-trigger
+  namespace: media
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kometa-trigger
+subjects:
+  - kind: ServiceAccount
+    name: kometa-trigger
+    namespace: media

--- a/kubernetes/apps/media/kometa/app/values.yaml
+++ b/kubernetes/apps/media/kometa/app/values.yaml
@@ -10,6 +10,38 @@ controllers:
       concurrencyPolicy: Forbid
       successfulJobsHistory: 1
       failedJobsHistory: 1
+    serviceAccount:
+      identifier: kometa
+    initContainers:
+      # Serialize kometa runs across ALL jobs (scheduled + webhook-triggered):
+      # wait until no other kometa job is active, then proceed. Queue-style,
+      # so triggered runs are delayed instead of dropped, and state lives in
+      # the API server (nothing to go stale, unlike a lockfile).
+      wait-for-turn:
+        image:
+          repository: docker.io/alpine/k8s
+          tag: 1.36.2
+        env:
+          JOB_NAME:
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['job-name']
+        command:
+          - sh
+          - -c
+          - |
+            while true; do
+              active=$(kubectl get jobs -n media -o json | jq -r --arg self "$JOB_NAME" \
+                '[.items[] | select(.metadata.name != $self)
+                           | select(.metadata.name | startswith("kometa"))
+                           | select((.status.active // 0) > 0)] | length')
+              if [ "$active" = "0" ]; then
+                echo "no other kometa jobs active - proceeding"
+                exit 0
+              fi
+              echo "$active other kometa job(s) active - waiting 30s"
+              sleep 30
+            done
     containers:
       app:
         image:
@@ -81,3 +113,5 @@ persistence:
     type: emptyDir
     globalMounts:
       - path: /tmp
+serviceAccount:
+  kometa: {}

--- a/kubernetes/apps/media/posterizarr/app/external-secret.yaml
+++ b/kubernetes/apps/media/posterizarr/app/external-secret.yaml
@@ -19,6 +19,9 @@ spec:
         # web UI owns the file afterwards - runtime changes are made there and
         # are never overwritten. Keep notable UI changes mirrored here so a
         # future re-seed doesn't regress them.
+        # Notification: Apprise posts run-completion JSON to the n8n webhook,
+        # which spawns an ad-hoc kometa Job (see kometa/app/rbac.yaml) so
+        # overlays land shortly after new posters instead of at 06:00.
         # Upload semantics: PlexUpload ("Enable Plex Upload") ALWAYS uploads
         # generated art; UploadExistingAssets only uploads when Plex's current
         # art lacks Posterizarr/Kometa/TCM EXIF markers. PlexUpload is OFF:
@@ -70,8 +73,8 @@ spec:
               "ReplaceThumbwithBackdrop": "false"
             },
             "Notification": {
-              "SendNotification": "false",
-              "AppriseUrl": "",
+              "SendNotification": "true",
+              "AppriseUrl": "json://n8n.tools.svc.cluster.local:5678/webhook/kometa-trigger",
               "Discord": "",
               "UseUptimeKuma": "false",
               "UptimeKumaUrl": "",


### PR DESCRIPTION
## Summary

Infrastructure for the **poster pipeline**: when Posterizarr finishes a run (e.g. Tautulli-triggered on new content), its Apprise notification POSTs to an n8n webhook, and an n8n workflow spawns an ad-hoc Kometa Job from the existing CronJob template — so overlays land minutes after new posters instead of waiting for the 06:00 schedule.

```
Tautulli ──▶ Posterizarr run ──▶ Apprise json:// webhook ──▶ n8n ──▶ K8s API: create Job from cronjob/kometa
                                                                          │
                                                        wait-for-turn init: queue behind any active kometa job
```

## Changes

- **`kometa/app/values.yaml`** — `wait-for-turn` initContainer on the CronJob: polls the Kubernetes API (via a new app-template-managed `kometa` ServiceAccount) and waits until no *other* kometa job is active before letting the run start. All runs — scheduled and triggered — serialize into a queue instead of overlapping or being dropped. State lives in the API server, so nothing can go stale (a lockfile on the RWO config PVC would be fragile against OOMKills and cross-node Multi-Attach). Init image `alpine/k8s` pinned to the cluster's kubectl minor.
- **`kometa/app/rbac.yaml`** —
  - `kometa-trigger` ServiceAccount + long-lived token Secret + Role (`get` cronjobs, `get/list/create` jobs) for n8n's bearer-token credential.
  - `kometa-runner` Role/RoleBinding (`get/list` jobs only) for the pod's own ServiceAccount.
- **`posterizarr/app/external-secret.yaml`** — seed config mirrors the Notification settings the UI will get: `SendNotification: true`, `AppriseUrl: json://n8n.tools.svc.cluster.local:5678/webhook/kometa-trigger`.

The initContainer applies on merge (next scheduled run waits ~0s when nothing else is active — a no-op in practice). The webhook path stays inert until the n8n workflow exists and the Posterizarr UI settings are flipped.

The Movies ribbon-overlay removal was split out into its own PR: #1675 (stacked on this one).

## Activation steps (manual, after the current full run finishes)

1. Build the n8n workflow — now just **webhook → fetch cronjob → create Job** (no skip-if-running node; the initContainer handles serialization).
2. Create the n8n Header Auth credential from `kubectl -n media get secret kometa-trigger-token -o jsonpath='{.data.token}' | base64 -d`.
3. Set `SendNotification` + `AppriseUrl` in the Posterizarr UI to match the seed.

## Notes

- The nightly 06:00 Kometa run remains the full reconciler; triggered runs are opportunistic extras that now queue behind it if needed. `concurrencyPolicy: Forbid` still dedupes the schedule itself.
- Posterizarr's scheduled 05:00 run completing will also fire the webhook — harmless (it just pre-empts 06:00).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR