### PR TITLE
fix(healthchecks): send Host header in probes to satisfy ALLOWED_HOSTS

### DIFF
--- a/kubernetes/apps/observability/healthchecks/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/healthchecks/app/helmrelease.yaml
@@ -46,6 +46,9 @@ spec:
                   httpGet:
                     path: /
                     port: &port 8000
+                    httpHeaders:
+                      - name: Host
+                        value: healthchecks.vaderrp.com
                   initialDelaySeconds: 15
                   periodSeconds: 10
                   timeoutSeconds: 3


### PR DESCRIPTION
Fixes the Healthchecks CrashLoopBackOff introduced in #1595.

## Problem

The pod itself was healthy (migrations applied, workers and sendalerts/sendreports daemons running), but every liveness/readiness probe returned **HTTP 400**. Kubelet probes request the pod IP directly, so the `Host` header was `<pod-ip>:8000` — which Django rejects with `DisallowedHost` because `ALLOWED_HOSTS` is pinned to `healthchecks.vaderrp.com`. Failed probes → kubelet kills the healthy pod → crash loop.

## Fix

Add an explicit `Host: healthchecks.vaderrp.com` header to the probe `httpGet` spec (shared anchor covers both liveness and readiness). This keeps `ALLOWED_HOSTS` strict rather than widening it to `*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvuQasuBxgcEaYfGpPJR8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvuQasuBxgcEaYfGpPJR8n)_