### PR TITLE
fix(healthchecks): allow integrations to reach private IPs

### DIFF
--- a/kubernetes/apps/observability/healthchecks/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/healthchecks/app/helmrelease.yaml
@@ -35,6 +35,8 @@ spec:
               DB_NAME: /data/hc.sqlite
               REGISTRATION_OPEN: "False"
               DEBUG: "False"
+              # Allow webhook/ntfy integrations targeting in-cluster services
+              INTEGRATIONS_ALLOW_PRIVATE_IPS: "True"
             envFrom:
               - secretRef:
                   name: healthchecks-secret


### PR DESCRIPTION
Follow-up to #1595/#1601. Configuring the ntfy integration in Healthchecks against the in-cluster service URL (`http://ntfy.observability.svc.cluster.local:8080`) fails with:

> Could not send a test notification. Connections to private IP addresses are not allowed.

This is Healthchecks' SSRF protection (`INTEGRATIONS_ALLOW_PRIVATE_IPS`, default `False`). In this cluster the integration targets are private by design — ntfy's service, and any future webhook targets on the LAN — and split DNS would resolve even the public hostnames to private gateway IPs anyway. Set it to `True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvuQasuBxgcEaYfGpPJR8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvuQasuBxgcEaYfGpPJR8n)_