### PR TITLE
feat(storage): sync MinIO backup buckets to Google Drive via rclone CronJob

### DIFF
--- a/docs/superpowers/specs/2026-07-27-minio-gdrive-sync-design.md
+++ b/docs/superpowers/specs/2026-07-27-minio-gdrive-sync-design.md
@@ -1,0 +1,98 @@
+# MinIO → Google Drive backup sync — design
+
+Date: 2026-07-27
+Status: approved (pending implementation)
+
+## Purpose
+
+Give the cluster's MinIO backup buckets an offsite 3-2-1 copy in Google Drive.
+TrueNAS Cloud Sync cannot reach them (`/mnt/.ix-apps` is outside the pool
+mountpoint), so a CronJob in the cluster syncs them over the S3 API instead.
+
+## Scope
+
+Buckets (explicit list, not auto-discovered):
+
+```
+cloudnative-pg  mariadb  kopia  volsync  parsedmarc  n8n  stalwart
+```
+
+`harbor` is excluded — it holds the mirror cache of public images plus
+custom images/OCI artifacts, but the custom ones are built and pushed from
+GitHub, so everything in it can be rebuilt. Empty buckets
+(`loki`, `elasticsearch-snapshots`, `opensearch-snapshots`, `falco-forensics`)
+are excluded deliberately: auto-discovery would silently start pushing
+high-churn chunk data if e.g. Loki ever begins writing to its bucket.
+Adding a bucket later is a one-line edit.
+
+## Architecture
+
+New app at `kubernetes/apps/storage/minio-gdrive-sync/` (standard ks.yaml +
+`app/` layout, modeled on parsedmarc):
+
+| File | Purpose |
+|---|---|
+| `ks.yaml` | Flux Kustomization |
+| `app/cronjob.yaml` | CronJob, `rclone/rclone` image, daily 05:00, `concurrencyPolicy: Forbid` |
+| `app/external-secret.yaml` | Pulls all secrets into one K8s Secret |
+| `app/configmap.yaml` | Entrypoint script (see below) |
+| `app/kustomization.yaml` | Wires the above |
+
+Schedule rationale: TrueNAS Cloud Sync tasks run 00:00–03:00; nightly
+VolSync/CNPG backups earlier. 05:00 syncs a quiet repo.
+
+## Secrets (ExternalSecret, ClusterSecretStore `bitwarden-fields`)
+
+| K8s key | Vaultwarden item | property |
+|---|---|---|
+| `ENCRYPTION_PASSWORD` | `980055b1-e67e-43b3-8634-87545f4cce16` | `encryption_password` |
+| `ENCRYPTION_SALT` | `980055b1-e67e-43b3-8634-87545f4cce16` | `encryption_salt` |
+| `GDRIVE_TOKEN` | `980055b1-e67e-43b3-8634-87545f4cce16` | `gdrive_token` |
+| `MINIO_ACCESS_KEY` | `ed32aa71-d74b-43bc-a467-aaa2569f532f` | `aws-access-key-id` |
+| `MINIO_SECRET_KEY` | `ed32aa71-d74b-43bc-a467-aaa2569f532f` | `aws-secret-access-key` |
+
+`gdrive_token` is the full JSON printed by `rclone authorize "drive"`
+(rclone's built-in OAuth client; no client id/secret of our own).
+The MinIO key is the same `ncpg-access` key CNPG/MariaDB use (verified
+identical in-cluster 2026-07-27).
+
+## Entrypoint script
+
+rclone crypt requires *obscured* passwords in config, so the script builds
+`rclone.conf` at runtime:
+
+1. `rclone obscure` on `ENCRYPTION_PASSWORD` and `ENCRYPTION_SALT`
+2. Write config with three remotes:
+   - `minio`: type s3, provider Minio, endpoint `https://minio.vaderrp.com:9000`
+   - `gdrive`: type drive, `token = $GDRIVE_TOKEN`
+   - `crypt`: wraps `gdrive:TrueNAS/MinIO`, `filename_encryption = off`,
+     `directory_name_encryption = false` (matches the TrueNAS Cloud Sync
+     task style — contents encrypted, names readable)
+3. For each bucket: `rclone sync minio:<bucket> crypt:<bucket> --fast-list`
+4. Exit non-zero if any bucket sync failed (so the Job shows Failed)
+
+Deletion semantics: `sync` (mirror). Source buckets are self-pruning backup
+repos (kopia/volsync maintenance, CNPG retention); `copy` would grow
+unboundedly. Drive-side size ≈ live MinIO data (~172 GB currently).
+
+## Error handling / visibility
+
+- `failedJobsHistoryLimit: 3`, `restartPolicy: OnFailure` (bounded via `backoffLimit`)
+- Existing kube-prometheus-stack failed-Job alerting covers notification;
+  no custom alerts.
+
+## Restore path
+
+`rclone sync crypt:<bucket> minio:<bucket>` with the same config, or any
+rclone with the crypt password+salt from Vaultwarden. Filenames are
+plaintext in Drive; contents are unrecoverable without password+salt.
+
+## Risks / open items
+
+- **MinIO policy**: `ncpg-access` must have read+list on all seven buckets.
+  Verify on first run; AccessDenied on non-DB buckets ⇒ widen policy or
+  create a dedicated read-only key.
+- Google Drive uploads cap at ~750 GB/day/account — initial ~172 GB plus the
+  TrueNAS tasks fits, but the very first run may be slow.
+- rclone refreshes the Drive access token in-memory only (config is from a
+  Secret); the stored refresh token does not rotate, so this is fine.

--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - ./volsync/ks.yaml
   - ./kopia/ks.yaml
   - ./harbor/ks.yaml
+  - ./minio-gdrive-sync/ks.yaml
 components:
   - ../../components/common

--- a/kubernetes/apps/storage/minio-gdrive-sync/app/configmap.yaml
+++ b/kubernetes/apps/storage/minio-gdrive-sync/app/configmap.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minio-gdrive-sync-script
+data:
+  sync.sh: |
+    #!/bin/sh
+    set -eu
+
+    # rclone crypt requires obscured passwords in config
+    PASS=$(rclone obscure "$ENCRYPTION_PASSWORD")
+    SALT=$(rclone obscure "$ENCRYPTION_SALT")
+
+    # GDRIVE_TOKEN must be the single-line JSON from `rclone authorize "drive"`
+    cat > /tmp/rclone.conf <<EOF
+    [minio]
+    type = s3
+    provider = Minio
+    endpoint = https://minio.vaderrp.com:9000
+    access_key_id = $MINIO_ACCESS_KEY
+    secret_access_key = $MINIO_SECRET_KEY
+
+    [gdrive]
+    type = drive
+    scope = drive
+    token = $GDRIVE_TOKEN
+
+    [crypt]
+    type = crypt
+    remote = gdrive:TrueNAS/MinIO
+    filename_encryption = off
+    directory_name_encryption = false
+    password = $PASS
+    password2 = $SALT
+    EOF
+
+    rc=0
+    for bucket in $BUCKETS; do
+      echo "=== syncing $bucket ==="
+      rclone --config /tmp/rclone.conf sync "minio:$bucket" "crypt:$bucket" \
+        --fast-list --transfers 4 --stats 5m --stats-log-level NOTICE || rc=1
+    done
+    exit $rc

--- a/kubernetes/apps/storage/minio-gdrive-sync/app/cronjob.yaml
+++ b/kubernetes/apps/storage/minio-gdrive-sync/app/cronjob.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: minio-gdrive-sync
+spec:
+  schedule: "0 5 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: rclone
+              image: rclone/rclone:1.74.4
+              command: ["/bin/sh", "/scripts/sync.sh"]
+              env:
+                - name: BUCKETS
+                  value: "cloudnative-pg mariadb kopia volsync parsedmarc n8n stalwart"
+              envFrom:
+                - secretRef:
+                    name: minio-gdrive-sync
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  memory: 1Gi
+          volumes:
+            - name: script
+              configMap:
+                name: minio-gdrive-sync-script

--- a/kubernetes/apps/storage/minio-gdrive-sync/app/external-secret.yaml
+++ b/kubernetes/apps/storage/minio-gdrive-sync/app/external-secret.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-gdrive-sync
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-fields
+    kind: ClusterSecretStore
+  target:
+    name: minio-gdrive-sync
+    creationPolicy: Owner
+  data:
+    - secretKey: ENCRYPTION_PASSWORD
+      remoteRef:
+        key: 980055b1-e67e-43b3-8634-87545f4cce16
+        property: encryption_password
+    - secretKey: ENCRYPTION_SALT
+      remoteRef:
+        key: 980055b1-e67e-43b3-8634-87545f4cce16
+        property: encryption_salt
+    - secretKey: GDRIVE_TOKEN
+      remoteRef:
+        key: 980055b1-e67e-43b3-8634-87545f4cce16
+        property: gdrive_token
+    - secretKey: MINIO_ACCESS_KEY
+      remoteRef:
+        key: ed32aa71-d74b-43bc-a467-aaa2569f532f
+        property: aws-access-key-id
+    - secretKey: MINIO_SECRET_KEY
+      remoteRef:
+        key: ed32aa71-d74b-43bc-a467-aaa2569f532f
+        property: aws-secret-access-key

--- a/kubernetes/apps/storage/minio-gdrive-sync/app/kustomization.yaml
+++ b/kubernetes/apps/storage/minio-gdrive-sync/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml
+  - configmap.yaml
+  - cronjob.yaml

--- a/kubernetes/apps/storage/minio-gdrive-sync/ks.yaml
+++ b/kubernetes/apps/storage/minio-gdrive-sync/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: minio-gdrive-sync
+  namespace: flux-system
+spec:
+  targetNamespace: storage
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: minio-gdrive-sync
+  path: "./kubernetes/apps/storage/minio-gdrive-sync/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary

Adds a daily CronJob (\`storage/minio-gdrive-sync\`) that mirrors the cluster's MinIO backup buckets to Google Drive as an offsite 3-2-1 copy. TrueNAS Cloud Sync cannot reach these buckets (the \`ix-apps\` dataset mounts outside the pool mountpoint), so the sync runs in-cluster over the S3 API instead.

- Buckets (explicit list): \`cloudnative-pg mariadb kopia volsync parsedmarc n8n stalwart\` — \`harbor\` excluded (rebuildable), empty buckets excluded deliberately so future high-churn writers (e.g. Loki) aren't picked up silently
- \`rclone sync\` through a crypt remote to \`Drive:/TrueNAS/MinIO/<bucket>\` — contents encrypted, filenames plaintext
- Runs 05:00, after the nightly backup jobs and TrueNAS Cloud Sync windows
- Secrets via ExternalSecret from Vaultwarden (\`bitwarden-fields\`): crypt password/salt + Drive OAuth token, plus the existing \`ncpg-access\` MinIO key
- Entrypoint script obscures crypt credentials at runtime and fails the Job if any bucket sync fails

Design doc: \`docs/superpowers/specs/2026-07-27-minio-gdrive-sync-design.md\`

## First-run notes

- If non-DB buckets return AccessDenied, the \`ncpg-access\` MinIO policy needs read+list on the listed buckets (or a dedicated read-only key)
- Initial upload is ~172 GB; later runs move deltas only

## Test plan

- [x] \`kubectl kustomize\` passes for app and storage overlays
- [ ] After merge: \`kubectl -n storage create job --from=cronjob/minio-gdrive-sync minio-gdrive-sync-manual\` and watch logs