### PR TITLE
fix(storage): use own Google OAuth client for minio-gdrive-sync

### DIFF
--- a/kubernetes/apps/storage/minio-gdrive-sync/app/configmap.yaml
+++ b/kubernetes/apps/storage/minio-gdrive-sync/app/configmap.yaml
@@ -24,6 +24,8 @@ data:
     [gdrive]
     type = drive
     scope = drive
+    client_id = $GDRIVE_CLIENT_ID
+    client_secret = $GDRIVE_CLIENT_SECRET
     token = $GDRIVE_TOKEN
 
     [crypt]

--- a/kubernetes/apps/storage/minio-gdrive-sync/app/external-secret.yaml
+++ b/kubernetes/apps/storage/minio-gdrive-sync/app/external-secret.yaml
@@ -24,6 +24,14 @@ spec:
       remoteRef:
         key: 980055b1-e67e-43b3-8634-87545f4cce16
         property: gdrive_token
+    - secretKey: GDRIVE_CLIENT_ID
+      remoteRef:
+        key: 980055b1-e67e-43b3-8634-87545f4cce16
+        property: rclone_client_id
+    - secretKey: GDRIVE_CLIENT_SECRET
+      remoteRef:
+        key: 980055b1-e67e-43b3-8634-87545f4cce16
+        property: rclone_client_secret
     - secretKey: MINIO_ACCESS_KEY
       remoteRef:
         key: ed32aa71-d74b-43bc-a467-aaa2569f532f


### PR DESCRIPTION
## Summary

rclone's shared Google Drive client_id is being retired during 2026 (the sync job logs a NOTICE about it every run). Switch the \`minio-gdrive-sync\` CronJob to a dedicated OAuth client:

- ExternalSecret now also pulls \`rclone_client_id\` / \`rclone_client_secret\` from the same Vaultwarden item (fields already in place, token re-authorized against the new client)
- \`[gdrive]\` remote config gains \`client_id\` / \`client_secret\`

No change to synced data — the crypt layer is independent of the OAuth client.

## Test plan

- [x] \`kubectl kustomize\` passes
- [ ] After merge: trigger a manual job and confirm the NOTICE is gone and transfers succeed