### PR TITLE
chore(storage): report minio-gdrive-sync stats every minute

### DIFF
--- a/kubernetes/apps/storage/minio-gdrive-sync/app/configmap.yaml
+++ b/kubernetes/apps/storage/minio-gdrive-sync/app/configmap.yaml
@@ -41,6 +41,6 @@ data:
     for bucket in $BUCKETS; do
       echo "=== syncing $bucket ==="
       rclone --config /tmp/rclone.conf sync "minio:$bucket" "crypt:$bucket" \
-        --fast-list --transfers 4 --stats 5m --stats-log-level NOTICE || rc=1
+        --fast-list --transfers 4 --stats 1m --stats-log-level NOTICE || rc=1
     done
     exit $rc


### PR DESCRIPTION
Bump rclone progress output from every 5 minutes to every minute for easier log-watching during large syncs.