### PR TITLE
fix(gatus): lower vaderrp.com cert-expiration threshold for short-lived certs

### DIFF
--- a/kubernetes/apps/observability/gatus/app/gatus-config.yaml
+++ b/kubernetes/apps/observability/gatus/app/gatus-config.yaml
@@ -67,7 +67,9 @@ endpoints:
       dns-resolver: tcp://1.1.1.1:53
     conditions:
       - "[DOMAIN_EXPIRATION] > 720h"
-      - "[CERTIFICATE_EXPIRATION] > 240h"
+      # NPMplus serves 7-day short-lived LE certs on the apex (max 168h
+      # lifetime, renewed around day 4-5) — alert only when renewal is overdue
+      - "[CERTIFICATE_EXPIRATION] > 48h"
     alerts:
       - type: ntfy
         send-on-resolved: true


### PR DESCRIPTION
Now that the apex TLS chain is fixed (NPMplus dead-host template + cert), the `vaderrp.com` Domains check completes its handshake — and immediately fails on `[CERTIFICATE_EXPIRATION] > 240h`, because NPMplus issues **7-day short-lived Let's Encrypt certificates** there. A cert with a 168h maximum lifetime can never have 240h remaining, so the old threshold is structurally unsatisfiable.

NPMplus/certbot renews these around day 4–5, so a healthy cert has ~48–168h remaining at all times. Lower the threshold to `> 48h`, which fires only when renewal is genuinely overdue while still leaving ~2 days of warning before actual expiry.

`shadowmorph.info` keeps `> 240h` — it's served via the Cloudflare proxy edge cert, which has a standard ~90-day lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvuQasuBxgcEaYfGpPJR8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvuQasuBxgcEaYfGpPJR8n)_