### PR TITLE
feat(gatus): add erinko.fi domain and cert expiration check

### DIFF
--- a/kubernetes/apps/observability/gatus/app/gatus-config.yaml
+++ b/kubernetes/apps/observability/gatus/app/gatus-config.yaml
@@ -75,6 +75,20 @@ endpoints:
         send-on-resolved: true
         failure-threshold: 3
         success-threshold: 5
+  - name: erinko.fi domain and expiration
+    group: Domains
+    url: "https://mail.erinko.fi"
+    interval: 1h
+    client:
+      dns-resolver: tcp://1.1.1.1:53
+    conditions:
+      - "[DOMAIN_EXPIRATION] > 720h"
+      - "[CERTIFICATE_EXPIRATION] > 240h"
+    alerts:
+      - type: ntfy
+        send-on-resolved: true
+        failure-threshold: 3
+        success-threshold: 5
   - name: shadowmorph.info domain and expiration
     group: Domains
     url: "https://shadowmorph.info"


### PR DESCRIPTION
Adds a third Domains-group endpoint covering `erinko.fi`, checked via `https://mail.erinko.fi` — the mail server terminates TLS with a standard Let's Encrypt cert, while the apex is not HTTPS-served. Same shape as the existing entries: hourly interval, public DNS resolver, `DOMAIN_EXPIRATION > 720h` + `CERTIFICATE_EXPIRATION > 240h` (standard 90-day cert, so the 240h threshold applies — unlike vaderrp.com's short-lived certs), ntfy alerts with send-on-resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvuQasuBxgcEaYfGpPJR8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvuQasuBxgcEaYfGpPJR8n)_