### PR TITLE
fix(gatus): check erinko.fi domain and cert on the apex

### DIFF
--- a/kubernetes/apps/observability/gatus/app/gatus-config.yaml
+++ b/kubernetes/apps/observability/gatus/app/gatus-config.yaml
@@ -77,7 +77,8 @@ endpoints:
         success-threshold: 5
   - name: erinko.fi domain and expiration
     group: Domains
-    url: "https://mail.erinko.fi"
+    # whois only answers for the registrable domain, so this targets the apex
+    url: "https://erinko.fi"
     interval: 1h
     client:
       dns-resolver: tcp://1.1.1.1:53


### PR DESCRIPTION
Follow-up to #1614. The combined check against `mail.erinko.fi` reported `DOMAIN_EXPIRATION` as `-2562047h47m16s` — Go's `math.MinInt64` duration sentinel, meaning the whois lookup produced no expiration date. Cause: whois registries only answer for the **registrable domain**, and the endpoint URL was a subdomain.

Point the whole check at the apex instead: `url: https://erinko.fi`, keeping both `DOMAIN_EXPIRATION > 720h` and `CERTIFICATE_EXPIRATION > 240h`. Whois now queries the registrable domain directly, and the apex terminates TLS, so both conditions evaluate against the same endpoint (mirroring the vaderrp.com and shadowmorph.info entries).

If the apex turns out not to serve a valid certificate after all, the cert condition will flag on the first hourly tick and the fallback is splitting the check (whois on apex, cert on `mail.erinko.fi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvuQasuBxgcEaYfGpPJR8n