### PR TITLE
feat(ruoka): serve the family menu from the cluster

### DIFF
--- a/kubernetes/apps/ruoka/kustomization.yaml
+++ b/kubernetes/apps/ruoka/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ruoka
+resources:
+  - namespace.yaml
+  - ./ruoka/ks.yaml
+components:
+  - ../../components/common

--- a/kubernetes/apps/ruoka/namespace.yaml
+++ b/kubernetes/apps/ruoka/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    goldilocks.fairwinds.com/vpa-update-mode: "auto"
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/ruoka/ruoka/app/github-pat-externalsecret.yaml
+++ b/kubernetes/apps/ruoka/ruoka/app/github-pat-externalsecret.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ruoka-github-pat
+  namespace: ruoka
+spec:
+  refreshInterval: 1h
+  target:
+    name: ruoka-github-pat
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      data:
+        username: "{{ .docker_username }}"
+        password: "{{ .github_package_read_pat }}"
+  data:
+    - secretKey: docker_username
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        key: f7f2ed36-37d2-438c-86b9-4e0d99c4b763
+        property: docker_username
+    - secretKey: github_package_read_pat
+      sourceRef:
+        storeRef:
+          name: bitwarden-fields
+          kind: ClusterSecretStore
+      remoteRef:
+        key: f7f2ed36-37d2-438c-86b9-4e0d99c4b763
+        property: github_package_read_pat

--- a/kubernetes/apps/ruoka/ruoka/app/helmrelease.yaml
+++ b/kubernetes/apps/ruoka/ruoka/app/helmrelease.yaml
@@ -1,0 +1,162 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ruoka
+  namespace: ruoka
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: ruoka
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      ruoka:
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        # The page has to exist before nginx accepts traffic, otherwise the
+        # first readiness probe races the first clone.
+        initContainers:
+          git-sync-init:
+            image: &gitSyncImage
+              repository: registry.k8s.io/git-sync/git-sync
+              tag: v4.7.0
+            # Same configuration as the sidecar, but clone once and exit.
+            args: ["--one-time"]
+            env: &gitSyncEnv
+              GITSYNC_REPO: https://github.com/operinko-labs/ruoka
+              GITSYNC_REF: dist
+              GITSYNC_ROOT: /www
+              GITSYNC_LINK: current
+              GITSYNC_DEPTH: 1
+              GITSYNC_PERIOD: 60s
+              GITSYNC_USERNAME:
+                valueFrom:
+                  secretKeyRef:
+                    name: ruoka-github-pat
+                    key: username
+              GITSYNC_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: ruoka-github-pat
+                    key: password
+            securityContext: &securityContext
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources: &gitSyncResources
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+
+        containers:
+          app:
+            image:
+              repository: docker.io/nginxinc/nginx-unprivileged
+              tag: 1.29-alpine
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probe
+            securityContext: *securityContext
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 64Mi
+
+          # Keeps /www/current pointing at the newest `dist` commit. A Sveltia
+          # edit is on the tablet within a minute of the Action finishing.
+          git-sync:
+            image: *gitSyncImage
+            env: *gitSyncEnv
+            securityContext: *securityContext
+            resources: *gitSyncResources
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: {type: RuntimeDefault}
+
+    service:
+      app:
+        controller: ruoka
+        ports:
+          http:
+            port: 80
+            targetPort: 8080
+
+    persistence:
+      # Shared between git-sync and nginx. Deliberately ephemeral: the whole
+      # site is ~40 kB, so re-cloning on pod start is cheaper than a PVC.
+      www:
+        type: emptyDir
+        advancedMounts:
+          ruoka:
+            git-sync-init:
+              - path: /www
+            git-sync:
+              - path: /www
+            app:
+              - path: /www
+                readOnly: true
+
+      nginx-config:
+        type: configMap
+        name: ruoka-nginx
+        advancedMounts:
+          ruoka:
+            app:
+              - path: /etc/nginx/conf.d/default.conf
+                subPath: nginx.conf
+                readOnly: true
+
+      # readOnlyRootFilesystem means nginx needs somewhere for its pid file and
+      # client temp paths, and git-sync needs somewhere for its git config.
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          ruoka:
+            app:
+              - path: /tmp
+            git-sync-init:
+              - path: /tmp
+            git-sync:
+              - path: /tmp
+
+      nginx-cache:
+        type: emptyDir
+        advancedMounts:
+          ruoka:
+            app:
+              - path: /var/cache/nginx
+
+    ingress:
+      app:
+        enabled: false

--- a/kubernetes/apps/ruoka/ruoka/app/httproute.yaml
+++ b/kubernetes/apps/ruoka/ruoka/app/httproute.yaml
@@ -29,40 +29,10 @@ spec:
   hostnames:
     - ruoka.vaderrp.com
   rules:
-    # Authentik sits in front of the editor only. Longer path prefixes win in
-    # Gateway API, so these two rules are matched before the catch-all below.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /admin
-      filters: &authenticated
-        - type: ExtensionRef
-          extensionRef:
-            group: traefik.io
-            kind: Middleware
-            name: traefik-warp
-        - type: ExtensionRef
-          extensionRef:
-            group: traefik.io
-            kind: Middleware
-            name: oidc-auth
-      backendRefs: &backend
-        - group: ""
-          kind: Service
-          name: ruoka
-          port: 80
-          weight: 1
-
-    # Where Authentik redirects back to. It has to carry the same middleware,
-    # otherwise the callback falls through to nginx and 404s mid-login.
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /oidc/callback
-      filters: *authenticated
-      backendRefs: *backend
-
-    # The menu itself — public, no login. That is the whole point of it.
+    # One rule for everything, including /admin. Sveltia authenticates against
+    # GitHub through its own OAuth broker, so an Authentik layer in front would
+    # only be a second login on the way to the same place — and the editor is
+    # inert without a GitHub token regardless.
     - matches:
         - path:
             type: PathPrefix
@@ -73,4 +43,9 @@ spec:
             group: traefik.io
             kind: Middleware
             name: traefik-warp
-      backendRefs: *backend
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: ruoka
+          port: 80
+          weight: 1

--- a/kubernetes/apps/ruoka/ruoka/app/httproute.yaml
+++ b/kubernetes/apps/ruoka/ruoka/app/httproute.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ruoka
+  namespace: ruoka
+  labels:
+    route.scope: external
+  annotations:
+    external-dns.alpha.kubernetes.io/target: external.vaderrp.com
+    gatus.home-operations.com/enabled: "true"
+    gatus.home-operations.com/endpoint: |
+      group: Default
+      url: "https://ruoka.vaderrp.com/healthz"
+      conditions:
+        - "[STATUS] == 200"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/name: Ruokalista
+    gethomepage.dev/icon: mdi-silverware-fork-knife
+    gethomepage.dev/href: https://ruoka.vaderrp.com
+    gethomepage.dev/pod-selector: app.kubernetes.io/name=ruoka
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-public
+      namespace: network
+  hostnames:
+    - ruoka.vaderrp.com
+  rules:
+    # Authentik sits in front of the editor only. Longer path prefixes win in
+    # Gateway API, so these two rules are matched before the catch-all below.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /admin
+      filters: &authenticated
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: traefik-warp
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: oidc-auth
+      backendRefs: &backend
+        - group: ""
+          kind: Service
+          name: ruoka
+          port: 80
+          weight: 1
+
+    # Where Authentik redirects back to. It has to carry the same middleware,
+    # otherwise the callback falls through to nginx and 404s mid-login.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /oidc/callback
+      filters: *authenticated
+      backendRefs: *backend
+
+    # The menu itself — public, no login. That is the whole point of it.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: traefik-warp
+      backendRefs: *backend

--- a/kubernetes/apps/ruoka/ruoka/app/kustomization.yaml
+++ b/kubernetes/apps/ruoka/ruoka/app/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ruoka
+resources:
+  - ./github-pat-externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+configMapGenerator:
+  - name: ruoka-nginx
+    files:
+      - nginx.conf
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/ruoka/ruoka/app/nginx.conf
+++ b/kubernetes/apps/ruoka/ruoka/app/nginx.conf
@@ -1,0 +1,65 @@
+# Serves the built ruokalista page out of the git-sync worktree.
+#
+# git-sync keeps /www/current pointing at a complete checkout of the `dist`
+# branch and only moves the symlink once a fetch has fully landed, so nginx
+# never serves a half-written page. `root` is re-resolved per request, which is
+# what makes the swap visible without a reload.
+
+server {
+    listen 8080;
+    server_name _;
+
+    root /www/current;
+    index index.html;
+
+    # The page is one self-contained file; nothing here is big enough to
+    # warrant sendfile tuning, but gzip earns its keep on 29 kB of inline CSS.
+    gzip on;
+    gzip_types text/css application/javascript application/json application/manifest+json image/svg+xml;
+    gzip_min_length 1024;
+
+    # Liveness/readiness. Answered by nginx itself so it stays up even if the
+    # worktree is missing — that distinction matters when debugging git-sync.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+
+    # Never cache the entry points: a menu edit has to show up on the fridge
+    # tablet on the next refresh, not whenever the browser feels like it.
+    location = / {
+        add_header Cache-Control "no-cache";
+        try_files /index.html =404;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
+    # A stale service worker would pin an old page indefinitely.
+    location = /sw.js {
+        add_header Cache-Control "no-cache";
+    }
+
+    location = /manifest.json {
+        add_header Cache-Control "no-cache";
+    }
+
+    # Sveltia CMS. Static files, but the same reasoning applies — the admin
+    # bundle is fetched from a CDN by index.html, so only the shell is here.
+    location /admin {
+        add_header Cache-Control "no-cache";
+        try_files $uri $uri/ /admin/index.html;
+    }
+
+    # Icons are content-addressed by name and change ~never.
+    location ~* \.(png|ico|svg|webmanifest)$ {
+        add_header Cache-Control "public, max-age=604800";
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}

--- a/kubernetes/apps/ruoka/ruoka/app/ocirepository.yaml
+++ b/kubernetes/apps/ruoka/ruoka/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ruoka
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ruoka/ruoka/ks.yaml
+++ b/kubernetes/apps/ruoka/ruoka/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ruoka
+  namespace: flux-system
+spec:
+  targetNamespace: ruoka
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: ruoka
+  interval: 30m
+  path: ./kubernetes/apps/ruoka/ruoka/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  timeout: 5m
+  decryption:
+    provider: sops


### PR DESCRIPTION
Adds `ruoka.vaderrp.com` — the family dinner plan from [`operinko-labs/ruoka`](https://github.com/operinko-labs/ruoka), previously served by the NPMplus LXC.

## What it does

nginx serves a static page kept current by a `git-sync` sidecar following the app repo's `dist` branch. The app repo's Action already publishes the built site there; `git-sync` re-points `/www/current` when that branch moves, so a Sveltia edit is live about a minute later. An init container (`--one-time`) does the first clone so nginx never answers a probe against an empty root.

```
kubernetes/apps/ruoka/
├── kustomization.yaml          # namespace + common component
├── namespace.yaml
└── ruoka/
    ├── ks.yaml
    └── app/
        ├── ocirepository.yaml          # app-template 4.6.2
        ├── helmrelease.yaml            # nginx + git-sync
        ├── nginx.conf                  # → ruoka-nginx ConfigMap
        ├── httproute.yaml
        └── github-pat-externalsecret.yaml
```

## Why no image build

The other repos in the org build an image per push, which is right for them — a deploy follows a code change. Here a "deploy" is someone changing Thursday to pancakes from their phone: a ~2 kB JSON edit. Putting that through buildah, a Harbor push and a manifest tag-bump is more machinery than the payload justifies, and it would churn a Harbor project weekly.

The trade-offs, stated plainly: the pod needs GitHub reachable on start, and a rollback is a revert on the `dist` branch rather than repointing a tag. The whole site is ~40 kB, so the `emptyDir` re-clone on restart is free.

## Routing

Public via `gateway-public`, one catch-all rule, `/admin` included. The Sveltia editor authenticates to GitHub through its own OAuth broker ([`sveltia-cms-auth`](https://github.com/sveltia/sveltia-cms-auth) as a Cloudflare Worker, source in [`operinko-labs/ruoka-admin`](https://github.com/operinko-labs/ruoka-admin)), so an `oidc-auth` layer in front would only be a second login on the way to the same place — and the editor is inert without a GitHub token regardless. An earlier revision of this branch had Authentik on `/admin` plus a companion `/oidc/callback` rule; both are gone.

The tunnel already routes `*.vaderrp.com`, so no `cloudflare-tunnel` change is needed; external-dns creates the record from the HTTPRoute annotation.

## One thing to check before this reconciles

**PAT scope.** The ExternalSecret reuses the same Bitwarden item as `hietamakidojo`/`leo-cal` (`github_package_read_pat`), which those apps use as git-clone credentials for private `operinko-labs` repos. If that PAT is fine-grained and scoped per-repository, it needs `ruoka` added to it or `git-sync` will fail to clone.

(The Authentik redirect URI previously listed here no longer applies.)

## Validation

Run locally against the real chart, not just eyeballed:

- `kustomize build` on both `kubernetes/apps/ruoka` and the `app/` directory
- `kubeconform -strict -ignore-missing-schemas` — 0 invalid
- `yamllint` — clean
- HelmRelease `values` validated against app-template/common **4.6.2**'s published `values.schema.json` — 0 errors (schema confirmed strict for `persistence`, mount keys and service ports)
- Read the chart's `container/fields/_volumeMounts.tpl` and `pod/fields/_initContainers.tpl` at the `common-4.6.2` tag to confirm init containers resolve `advancedMounts` by their own identifier — they route through the same `container.spec` helper, so `advancedMounts.ruoka.git-sync-init` is honoured.

That last check also surfaced a live footgun worth knowing: a `persistence` item with *no* mount config is mounted at `/<identifier>` in **every** container. All four items here declare explicit mounts. `git-sync` gets a writable `/tmp` alongside nginx, matching how `bazarr` runs the same image under `readOnlyRootFilesystem`.

Not run: `helm template` — `get.helm.sh` and `pkg-containers.githubusercontent.com` are both blocked by this environment's egress policy, so the chart tarball couldn't be fetched. Schema validation plus reading the template source is the closest available substitute.