### PR TITLE
fix(ruoka): stop nginx redirecting /admin to port 8080

### DIFF
--- a/kubernetes/apps/ruoka/ruoka/app/nginx.conf
+++ b/kubernetes/apps/ruoka/ruoka/app/nginx.conf
@@ -12,6 +12,14 @@ server {
     root /www/current;
     index index.html;
 
+    # Emit relative Location headers. `/admin` is a directory, so nginx 301s to
+    # add the trailing slash — and left to itself it builds that redirect from
+    # what it can see locally, which is http and port 8080. The client asked
+    # Traefik for https on 443, so the absolute form sends browsers to
+    # http://ruoka.vaderrp.com:8080/admin/ and they hang. A relative redirect
+    # carries no scheme, host or port, so the browser keeps its own.
+    absolute_redirect off;
+
     # The page is one self-contained file; nothing here is big enough to
     # warrant sendfile tuning, but gzip earns its keep on 29 kB of inline CSS.
     gzip on;


### PR DESCRIPTION
Follow-up to #1620. Opening <https://ruoka.vaderrp.com/admin> redirects the browser to `http://ruoka.vaderrp.com:8080/admin/`, which hangs.

## Cause

`/admin` is a directory, so nginx returns a 301 to add the trailing slash. By default it builds that `Location` as an absolute URI from what it can see *inside the pod* — scheme `http`, and its own listen port `8080`. TLS is terminated at Traefik, so nginx has no idea the client arrived on `https` at `443`, and it hands back a URL pointing at a port nothing publishes.

`absolute_redirect off` makes nginx emit a relative `Location: /admin/`, carrying no scheme, host or port, so the browser keeps the ones it already had.

## Verified, not assumed

Ran nginx 1.24 locally against this exact server block, with a `/admin/` directory in the docroot:

| `absolute_redirect` | `GET /admin` |
|---|---|
| `on` (nginx default) | `301` → `Location: http://127.0.0.1:8080/admin/` |
| `off` (this PR) | `301` → `Location: /admin/` |

The `on` row reproduces the reported symptom exactly, including the port. With the fix in place: `/admin/` → 200, `/admin/config.yml` → 200, `/` → 200, `/healthz` → 200.

Also re-ran `kustomize build`, `kubeconform -strict` and `yamllint` — all clean.

## Note on scope

This fixes the redirect nginx itself emits. It is not an http→https redirect at the edge — there is currently no HTTP listener on either gateway and no `redirections` block on the Traefik entrypoints, so plain `http://` to the cluster isn't answered at all. That's a separate, cluster-wide decision and deliberately not bundled here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mzrq5rbyotg76MPL46e5De)_