### PR TITLE
feat(traefik): redirect http to https at the web entrypoint

### DIFF
--- a/kubernetes/apps/network/traefik/app/helmrelease.yaml
+++ b/kubernetes/apps/network/traefik/app/helmrelease.yaml
@@ -144,6 +144,18 @@ spec:
     ports:
       web:
         port: 80
+        # Nothing is routed over plain HTTP — both gateways declare only HTTPS
+        # listeners — so without this, port 80 accepts a connection and then
+        # answers nothing. Redirecting at the entrypoint catches every hostname
+        # on both gateways at once, before any route matching. Safe for cert
+        # issuance: the certificates are wildcards and therefore DNS-01, so no
+        # HTTP-01 challenge ever travels this path.
+        http:
+          redirections:
+            entryPoint:
+              to: websecure
+              scheme: https
+              permanent: true
       websecure:
         port: 443
         http3:


### PR DESCRIPTION
There was no http→https redirect anywhere in the cluster. `gateway-public` and `gateway-internal` both declare only `protocol: HTTPS, port: 443`, and while Traefik exposes a `web` entrypoint on port 80, it had no `redirections` block — so port 80 accepted a connection and then answered nothing.

## Approach

Redirecting at the entrypoint rather than via Gateway API listeners, because it acts before route matching and therefore covers every hostname on both gateways in one block — `vaderrp.com`, `shadowmorph.info`, `erinko.fi`, `hietamakidojo.fi`, `ruskonkesateatteri.fi` and their apexes. The alternative would have been an HTTP listener plus a `RequestRedirect` HTTPRoute per domain, and a standing obligation to add another pair every time a domain is onboarded.

No risk to certificate issuance: every certificate here is a wildcard, so it must be DNS-01, and no HTTP-01 challenge travels port 80.

## Verified against the real chart

The nesting is easy to get wrong — I initially wrote `ports.web.redirections`, and the chart's own `values.schema.json` rejected it (`Additional property redirections is not allowed`). The correct path has an intermediate `http` key. Rendering the actual chart caught this; a YAML lint would not have.

`helm template oci://ghcr.io/traefik/helm/traefik --version 41.0.2` with the values as they build from this branch now emits:

```
--entryPoints.web.address=:80/tcp
--entryPoints.web.http.redirections.entryPoint.to=:443
--entryPoints.web.http.redirections.entryPoint.scheme=https
--entryPoints.web.http.redirections.entryPoint.permanent=true
```

Also clean: `yamllint kubernetes/`, and `kubeconform -strict` over `kubernetes/` with CI's ignore patterns — 689 resources, 0 invalid.

## Blast radius

This is shared networking, so worth stating plainly: it changes behaviour for every host in the cluster, not just the app that surfaced it. The change is strictly additive — port 80 currently returns nothing, so anything it starts doing is an improvement — but it does mean a rollout of the Traefik deployment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mzrq5rbyotg76MPL46e5De)_