### PR TITLE
fix(dns): clean up CoreDNS upstreams and follow the Technitium primary to .8

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -66,7 +66,7 @@ spec:
               192.168.0.221 truenas.vaderrp.com
               fallthrough
           - name: forward
-            parameters: . 192.168.7.9 192.168.7.8 10.42.1.179
+            parameters: . 192.168.7.8 192.168.7.9
             configBlock: |-
               policy round_robin
               force_tcp

--- a/kubernetes/apps/network/cluster-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cluster-dns/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
   values:
     provider: rfc2136
     extraArgs:
-      - --rfc2136-host=192.168.7.9
+      - --rfc2136-host=192.168.7.8
       - --rfc2136-port=53
       - --rfc2136-zone=cluster.local
       - --rfc2136-batch-change-size=50

--- a/kubernetes/apps/network/internal-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/internal-dns/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
   values:
     provider: rfc2136
     extraArgs:
-      - --rfc2136-host=192.168.7.9
+      - --rfc2136-host=192.168.7.8
       - --rfc2136-port=53
       - --rfc2136-zone=vaderrp.com
       - --rfc2136-batch-change-size=50


### PR DESCRIPTION
Follow-ups for the Technitium migration, to merge **when the primary flips to `ns1`**. Two independent commits, deliberately split — see the merge gate below, because one of them may not apply.

## ⚠️ Merge gate — check before merging

`f596c39` (the RFC2136 change) is **only correct if the primary's address actually becomes `.8`**.

- **If the NUC is renamed to `ns1` *and swapped onto* `.8`** → merge as-is.
- **If the NUC is renamed in place and keeps `.9`** → the primary never moves. **Drop `f596c39` before merging** and keep only the CoreDNS commit, otherwise external-dns will start writing dynamic updates to a secondary and record publication silently stops.

The commits are split precisely so the second can be dropped with one `git revert` without disturbing the first.

## `72180c8` — CoreDNS forward list *(applies either way)*

```diff
-parameters: . 192.168.7.9 192.168.7.8 10.42.1.179
+parameters: . 192.168.7.8 192.168.7.9
```

`10.42.1.179` is a hardcoded **pod-network** address — the in-cluster Technitium pod's cluster IP. Pod IPs change on every reschedule, so it has been unreliable for a while, and it can't survive the pod being decommissioned at all. Removed permanently.

`.8` stays: it's dark while the in-cluster instance is suspended and comes back when the replacement LXC takes that address. With `policy round_robin`, each dead entry costs a share of queries a connect timeout until CoreDNS marks it down.

Correct regardless of which node ends up at `.8`, since CoreDNS talks to both.

## `f596c39` — external-dns RFC2136 target *(conditional)*

```diff
-- --rfc2136-host=192.168.7.9
+- --rfc2136-host=192.168.7.8
```

Both instances (`internal-dns`, `cluster-dns`). Dynamic updates have to reach the cluster **primary**, not whichever node answers — which is also why this must never point at the VIP.

## Note on current state

With the in-cluster instance suspended, `192.168.7.8` is dark right now. That means `machine.network.nameservers` in `talos/machineconfig.yaml.j2` currently lists a dead address **first**, on every node — so host-level lookups cluster-wide are paying a timeout before falling back to `.9`. That's not fixed here (it needs a node roll, and it's Talos config rather than a manifest change), but it's worth doing sooner rather than at flip time.

Background and the full migration plan: #1633.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_