### PR TITLE
feat(scripts): pull the Technitium TLS bundle from NPMplus

### DIFF
--- a/scripts/technitium-cert-sync/README.md
+++ b/scripts/technitium-cert-sync/README.md
@@ -1,0 +1,119 @@
+# Technitium TLS bundle sync
+
+NPMplus is the only ACME client. It issues one certificate covering
+`technitium.vaderrp.com`, `*.dns.vaderrp.com` and `dns.vaderrp.com` via DNS-01
+through Cloudflare, and each Technitium LXC pulls the result on a timer,
+converts it to PKCS#12, and drops it where Technitium expects it.
+
+Design rationale, including why the nodes pull rather than NPMplus pushing:
+[`docs/networking/technitium-dns-ha.md`](../../docs/networking/technitium-dns-ha.md) §4.1.
+
+## Why pull
+
+A push would mean NPMplus holding an SSH credential able to write
+`/etc/dns/ssl.pfx` on every DNS server — root-equivalent over the whole DNS
+tier, held by the most network-exposed component in the chain. Pulling reverses
+that: each node holds a read-only credential for one directory, and a
+compromised NPMplus cannot write anything to a DNS server.
+
+## Prerequisites
+
+- NPMplus runs as a container with `/opt/npmplus:/data`, so the certificate it
+  writes to `/data/tls/certbot/live/npm-15/` is visible on the **LXC
+  filesystem** at `/opt/npmplus/tls/certbot/live/npm-15/`. Nothing inside the
+  container is touched, so image updates cannot break this.
+- A proxy host must stay attached to the certificate in NPMplus — it only
+  renews certificates that have one, even if nothing routes through it.
+
+## Install on NPMplus
+
+`privkey.pem` is root-owned `0600`, so the key goes in root's
+`authorized_keys`. `rrsync -ro` confines it to read-only access under one
+directory, which is what makes that acceptable.
+
+```sh
+# Debian ships rrsync in the rsync package. Confirm the path before using it.
+command -v rrsync || ls /usr/share/doc/rsync/scripts/
+```
+
+Scope the forced command to the **parent** of `live/`, not to `live/npm-15`:
+those entries are symlinks into a sibling `archive/` directory, and a
+restriction rooted at `live/npm-15` puts their targets outside the permitted
+subtree.
+
+```
+# /root/.ssh/authorized_keys on the NPMplus LXC
+command="rrsync -ro /opt/npmplus/tls/certbot",restrict ssh-ed25519 AAAA... technitium-cert-sync
+```
+
+Generate one key per node so either can be revoked independently.
+
+## Install on each Technitium node
+
+```sh
+install -m 0755 technitium-cert-sync.sh /usr/local/bin/
+install -m 0644 technitium-cert-sync.service technitium-cert-sync.timer /etc/systemd/system/
+
+systemctl daemon-reload
+systemctl enable --now technitium-cert-sync.timer
+
+# First run, watching the output
+systemctl start technitium-cert-sync.service
+journalctl -u technitium-cert-sync.service -n 20
+```
+
+Then in the Technitium admin UI, Settings → Optional Protocols:
+
+- **TLS Certificate File Path**: `/etc/dns/ssl.pfx`
+- **TLS Certificate Password**: leave empty
+
+Clustering replicates both of those settings, so the path and password must be
+identical on every node. The bundle contents are identical too, since one
+certificate is distributed.
+
+## Configuration
+
+The script reads four optional environment variables, all with defaults that
+match this deployment. Override via a systemd drop-in if needed:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `SRC_HOST` | `root@npmplus` | Host serving the bundle |
+| `SRC_PATH` | `live/npm-15` | Path **relative to the rrsync root** |
+| `OUT` | `/etc/dns/ssl.pfx` | Where Technitium reads the bundle |
+| `WORK` | `/var/lib/technitium-cert` | Scratch and last-synced copy |
+
+`SRC_PATH` tracks the NPMplus certificate ID. If the certificate is recreated
+in NPMplus it becomes `npm-16`, `npm-17` and so on, and this needs updating.
+
+## Verifying
+
+```sh
+systemctl list-timers technitium-cert-sync.timer
+openssl pkcs12 -in /etc/dns/ssl.pfx -passin pass: -nokeys | openssl x509 -noout -subject -dates -ext subjectAltName
+```
+
+Then check encrypted DNS actually serves it:
+
+```sh
+kdig -d +tls @ns1.dns.vaderrp.com google.com      # DoT, port 853
+kdig -d +https @ns1.dns.vaderrp.com google.com    # DoH, port 443
+```
+
+`kdig` is in the `knot-dnsutils` package.
+
+## Failure modes
+
+- **A broken pull is invisible from the outside.** NPMplus issues Let's Encrypt
+  *shortlived* certificates — 160 hours, renewed around day 4–5 — so a node
+  stops serving a valid certificate within about a week of the sync breaking,
+  not the 90 days a classic certificate would give. The Gatus checks on `:853`
+  in `kubernetes/apps/observability/gatus/` exist for exactly this and are the
+  reason a `48h` threshold is used rather than `240h`.
+- **The script never clobbers a good bundle.** If the fetch fails or returns an
+  empty file it exits non-zero without touching `/etc/dns/ssl.pfx`, leaving the
+  previous certificate in place until the next run. Failures surface in
+  `journalctl -u technitium-cert-sync`.
+- **The `-legacy` OpenSSL flags** mirror the old in-cluster initContainer and
+  are known to produce a bundle Technitium accepts. Modern PKCS#12 defaults may
+  work on current .NET but have not been verified here.

--- a/scripts/technitium-cert-sync/technitium-cert-sync.service
+++ b/scripts/technitium-cert-sync/technitium-cert-sync.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Sync Technitium TLS bundle from NPMplus
+Documentation=https://github.com/operinko-labs/homeops/blob/main/docs/networking/technitium-dns-ha.md
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/technitium-cert-sync.sh
+
+# The bundle is written to /etc/dns and state kept in /var/lib; nothing else
+# needs to be writable.
+ProtectSystem=full
+ProtectHome=yes
+PrivateTmp=yes
+NoNewPrivileges=yes

--- a/scripts/technitium-cert-sync/technitium-cert-sync.sh
+++ b/scripts/technitium-cert-sync/technitium-cert-sync.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Pull the TLS bundle NPMplus holds and hand it to Technitium as PKCS#12.
+#
+# Runs on each Technitium LXC from a systemd timer. NPMplus is the only ACME
+# client; the nodes never talk to Let's Encrypt or hold a Cloudflare token.
+# The pull direction is deliberate — NPMplus holds no credential that can write
+# to a DNS server, only the nodes hold a read-only one pointing back at it.
+#
+# Technitium reloads its bundle when the file's modification time changes, so
+# the swap must be atomic and must only happen when the source actually changed.
+set -Eeuo pipefail
+
+# Host serving the bundle. The forced command in its authorized_keys pins the
+# rsync root to /opt/npmplus/tls/certbot, so SRC_PATH is relative to that.
+readonly SRC_HOST="${SRC_HOST:-root@npmplus}"
+readonly SRC_PATH="${SRC_PATH:-live/npm-15}"
+
+# Where Technitium expects the bundle. Must match Settings -> Optional Protocols
+# -> TLS Certificate File Path, and must be identical on every node: clustering
+# replicates that setting, so a node-specific path would break the other node.
+readonly OUT="${OUT:-/etc/dns/ssl.pfx}"
+readonly WORK="${WORK:-/var/lib/technitium-cert}"
+
+log() { printf '%s %s\n' "$(date -Is)" "$*" >&2; }
+
+main() {
+    mkdir -p "${WORK}/new" "$(dirname "${OUT}")"
+
+    # -L is required: live/ holds symlinks into ../../archive/, and preserving
+    # them would land two dangling links on a host where that path is absent.
+    if ! rsync -aL --delete -e 'ssh -o BatchMode=yes' \
+        "${SRC_HOST}:${SRC_PATH}/" "${WORK}/new/"; then
+        log "ERROR: could not fetch bundle from ${SRC_HOST}; leaving ${OUT} untouched"
+        exit 1
+    fi
+
+    for f in fullchain.pem privkey.pem; do
+        if [[ ! -s "${WORK}/new/${f}" ]]; then
+            log "ERROR: ${f} missing or empty in fetched bundle; leaving ${OUT} untouched"
+            exit 1
+        fi
+    done
+
+    # A timer fires on schedule, not on renewal. Without this check every tick
+    # would rewrite the bundle and trigger a pointless certificate reload.
+    if [[ -f "${OUT}" ]] \
+        && cmp -s "${WORK}/new/fullchain.pem" "${WORK}/current/fullchain.pem" 2>/dev/null \
+        && cmp -s "${WORK}/new/privkey.pem" "${WORK}/current/privkey.pem" 2>/dev/null; then
+        exit 0
+    fi
+
+    # Technitium takes PKCS#12 only. The legacy algorithms mirror what the old
+    # in-cluster initContainer used and are known to produce a bundle it
+    # accepts; modern defaults may work but have not been verified here.
+    openssl pkcs12 -export -legacy \
+        -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1 \
+        -inkey "${WORK}/new/privkey.pem" \
+        -in "${WORK}/new/fullchain.pem" \
+        -out "${OUT}.tmp" -passout pass:
+
+    chmod 0600 "${OUT}.tmp"
+
+    # Rename rather than write in place: Technitium watches mtime, and an
+    # in-place write risks it reading a partially written bundle. The rename is
+    # atomic and refreshes the timestamp in one step, triggering the reload.
+    mv "${OUT}.tmp" "${OUT}"
+
+    rm -rf "${WORK}/current"
+    mv "${WORK}/new" "${WORK}/current"
+
+    local expiry
+    expiry="$(openssl x509 -in "${WORK}/current/fullchain.pem" -noout -enddate)"
+    log "installed new bundle at ${OUT} (${expiry})"
+}
+
+main "$@"

--- a/scripts/technitium-cert-sync/technitium-cert-sync.timer
+++ b/scripts/technitium-cert-sync/technitium-cert-sync.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Hourly Technitium TLS bundle sync from NPMplus
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1h
+# NPMplus issues Let's Encrypt shortlived certificates (160h, renewed around
+# day 4-5), so a daily pull leaves too little margin if one run fails. Hourly
+# is nearly free — the script exits early when the source has not changed.
+RandomizedDelaySec=5min
+# Both nodes run this; without a jitter they would hit NPMplus together.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Certificate distribution for the two Technitium LXCs. NPMplus is the only ACME client — one cert covering `technitium.vaderrp.com`, `*.dns.vaderrp.com` and `dns.vaderrp.com` via DNS-01 through Cloudflare — and each node pulls the result hourly, converts it to PKCS#12, and drops it where Technitium reads it.

Design rationale: #1633 §4.1. Nothing here is applied by Flux; it's installed on the LXCs by hand per the README.

## Why one issuer, and why pull

Issuing per node would put a Cloudflare token able to rewrite the public zone onto every DNS server, and that gets worse with each node added.

The direction is deliberate. A **push** would mean NPMplus holding an SSH credential able to write `/etc/dns/ssl.pfx` on every DNS server — root-equivalent over the whole DNS tier, held by the most network-exposed component in the chain. **Pulling** reverses the blast radius: each node holds a read-only credential for one directory, and a compromised NPMplus cannot write anything to a DNS server.

## Details that are load-bearing rather than incidental

- **`rsync -L`** — `live/` holds symlinks into `../../archive/`, and preserving them lands two dangling links on a node where that path doesn't exist.
- **The `rrsync` forced command is scoped to the parent of `live/`** for the same reason: the symlink targets sit outside `live/npm-15`, so a restriction rooted there can't serve them.
- **Change detection** — a timer fires on schedule, not on renewal, and Technitium reloads on mtime. Without the `cmp` guard every tick would trigger a pointless certificate reload.
- **Temp file plus rename** — Technitium watches mtime, so an in-place write risks it reading a partially written bundle.
- **Hourly, not daily** — NPMplus issues Let's Encrypt *shortlived* certs (160h, renewed around day 4–5), so daily leaves too little margin when a run fails. `RandomizedDelaySec` keeps both nodes off NPMplus simultaneously.

A failed or empty fetch exits non-zero without touching the existing bundle, so a broken sync degrades to a *stale* certificate rather than none.

## Files

| File | |
|---|---|
| `technitium-cert-sync.sh` | the pull, convert and atomic swap |
| `technitium-cert-sync.service` | oneshot, hardened with `ProtectSystem=full` |
| `technitium-cert-sync.timer` | hourly with jitter |
| `README.md` | install steps for both sides, verification, failure modes |

Shellcheck-clean against the repo's `.shellcheckrc`.

## Before this works

- `rrsync` forced command in root's `authorized_keys` on the NPMplus LXC, scoped to `/opt/npmplus/tls/certbot`. One key per node so either can be revoked independently.
- Technitium Settings → Optional Protocols: TLS Certificate File Path `/etc/dns/ssl.pfx`, password empty. Clustering replicates both, so they must match on every node.
- **Move `ns1`'s Web Service HTTPS port back off `443`.** DoT on `853` currently refuses connections on `ns1`, which confirms the encrypted protocols aren't starting for want of a certificate — the web service took `443` unopposed. Once a cert exists DoH will want that port back.
- `SRC_PATH` tracks the NPMplus certificate ID (`npm-15`). If the cert is recreated it becomes `npm-16` and this needs updating.

## Note on the Gatus checks

The `:853` expiry checks added in #1635 will stay red until this is deployed and DoT is actually serving. That's the intended behaviour — with 6-day certificates a broken sync is otherwise invisible for about a week, and `ns2` has been serving a certificate that expired in April without anything noticing.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_