### PR TITLE
fix(scripts): fetch the cert bundle over a fixed command, not rrsync

### DIFF
--- a/scripts/technitium-cert-sync/README.md
+++ b/scripts/technitium-cert-sync/README.md
@@ -27,26 +27,54 @@ compromised NPMplus cannot write anything to a DNS server.
 
 ## Install on NPMplus
 
-`privkey.pem` is root-owned `0600`, so the key goes in root's
-`authorized_keys`. `rrsync -ro` confines it to read-only access under one
-directory, which is what makes that acceptable.
+The NPMplus LXC runs **Alpine** with OpenSSH. `privkey.pem` is root-owned
+`0600`, so the key goes in root's `authorized_keys`; the forced command is what
+makes that acceptable.
+
+A fixed command is used rather than `rrsync`. Alpine does not package `rrsync`,
+and recent versions are a Python script that would pull `python3` onto a
+container host for no benefit — but the better reason is that `rrsync` exists to
+safely parse client-supplied rsync flags, and a fixed command has no such
+surface at all. `tar -h` also dereferences the `live/` symlinks server-side,
+which is more direct than asking the client to do it.
 
 ```sh
-# Debian ships rrsync in the rsync package. Confirm the path before using it.
-command -v rrsync || ls /usr/share/doc/rsync/scripts/
+# /usr/local/bin/cert-export on the NPMplus LXC, mode 0755
+#!/bin/sh
+exec tar -C /opt/npmplus/tls/certbot/live/npm-15 -czhf - fullchain.pem privkey.pem
 ```
 
-Scope the forced command to the **parent** of `live/`, not to `live/npm-15`:
-those entries are symlinks into a sibling `archive/` directory, and a
-restriction rooted at `live/npm-15` puts their targets outside the permitted
-subtree.
+`apk add tar` if busybox's tar does not accept `-h`.
 
 ```
-# /root/.ssh/authorized_keys on the NPMplus LXC
-command="rrsync -ro /opt/npmplus/tls/certbot",restrict ssh-ed25519 AAAA... technitium-cert-sync
+# /root/.ssh/authorized_keys — APPEND, do not overwrite
+command="/usr/local/bin/cert-export",restrict ssh-ed25519 AAAAC3Nza... ns1-cert-sync
 ```
 
-Generate one key per node so either can be revoked independently.
+> **Append.** This key can never open a shell, so if it replaces an existing key
+> rather than joining it, SSH shell access to the LXC is gone and recovery is
+> `pct enter <ctid>` from the Proxmox host.
+
+`restrict` requires OpenSSH 7.2+ and implies `no-pty`, `no-port-forwarding`,
+`no-agent-forwarding`, `no-X11-forwarding` and `no-user-rc`. On Dropbear, which
+does not support it, list those individually instead.
+
+Generate one key per node so either can be revoked independently:
+
+```sh
+ssh-keygen -t ed25519 -N '' -C 'ns1-cert-sync' -f /root/.ssh/technitium-cert-sync
+```
+
+Verify from the node — both commands must produce the same tarball, because the
+forced command ignores whatever the client asks for:
+
+```sh
+ssh -i /root/.ssh/technitium-cert-sync root@npmplus | tar -tzf -
+ssh -i /root/.ssh/technitium-cert-sync root@npmplus 'echo hello'
+```
+
+If the second prints `hello`, the forced command is not in effect and that key
+has a full root shell.
 
 ## Install on each Technitium node
 
@@ -79,12 +107,13 @@ match this deployment. Override via a systemd drop-in if needed:
 | Variable | Default | Meaning |
 |---|---|---|
 | `SRC_HOST` | `root@npmplus` | Host serving the bundle |
-| `SRC_PATH` | `live/npm-15` | Path **relative to the rrsync root** |
+| `SSH_KEY` | `/root/.ssh/technitium-cert-sync` | Key matching the forced command |
 | `OUT` | `/etc/dns/ssl.pfx` | Where Technitium reads the bundle |
 | `WORK` | `/var/lib/technitium-cert` | Scratch and last-synced copy |
 
-`SRC_PATH` tracks the NPMplus certificate ID. If the certificate is recreated
-in NPMplus it becomes `npm-16`, `npm-17` and so on, and this needs updating.
+The certificate ID lives in `/usr/local/bin/cert-export` on NPMplus rather than
+here. If the certificate is recreated it becomes `npm-16`, `npm-17` and so on,
+and that script needs updating — on one host, not on every node.
 
 ## Verifying
 

--- a/scripts/technitium-cert-sync/technitium-cert-sync.sh
+++ b/scripts/technitium-cert-sync/technitium-cert-sync.sh
@@ -10,10 +10,11 @@
 # the swap must be atomic and must only happen when the source actually changed.
 set -Eeuo pipefail
 
-# Host serving the bundle. The forced command in its authorized_keys pins the
-# rsync root to /opt/npmplus/tls/certbot, so SRC_PATH is relative to that.
+# Host serving the bundle. Its authorized_keys pins this key to a forced command
+# that tars the two PEMs to stdout, so there is nothing to request — whatever
+# command is sent is ignored, and the key cannot do anything else.
 readonly SRC_HOST="${SRC_HOST:-root@npmplus}"
-readonly SRC_PATH="${SRC_PATH:-live/npm-15}"
+readonly SSH_KEY="${SSH_KEY:-/root/.ssh/technitium-cert-sync}"
 
 # Where Technitium expects the bundle. Must match Settings -> Optional Protocols
 # -> TLS Certificate File Path, and must be identical on every node: clustering
@@ -24,12 +25,14 @@ readonly WORK="${WORK:-/var/lib/technitium-cert}"
 log() { printf '%s %s\n' "$(date -Is)" "$*" >&2; }
 
 main() {
+    rm -rf "${WORK}/new"
     mkdir -p "${WORK}/new" "$(dirname "${OUT}")"
 
-    # -L is required: live/ holds symlinks into ../../archive/, and preserving
-    # them would land two dangling links on a host where that path is absent.
-    if ! rsync -aL --delete -e 'ssh -o BatchMode=yes' \
-        "${SRC_HOST}:${SRC_PATH}/" "${WORK}/new/"; then
+    # The forced command tars the two PEMs to stdout with -h, so the symlinks
+    # into ../../archive/ are dereferenced server-side and we receive real
+    # files. Nothing here chooses what to fetch; the far side decides.
+    if ! ssh -o BatchMode=yes -i "${SSH_KEY}" "${SRC_HOST}" \
+        | tar -xzf - -C "${WORK}/new"; then
         log "ERROR: could not fetch bundle from ${SRC_HOST}; leaving ${OUT} untouched"
         exit 1
     fi


### PR DESCRIPTION
Follow-up to #1636. The NPMplus LXC turns out to run **Alpine**, which doesn't package `rrsync` — and recent versions are a Python script that would pull `python3` onto a container host to gain nothing.

## The change

The fetch becomes a fixed forced command on the NPMplus side:

```sh
# /usr/local/bin/cert-export
exec tar -C /opt/npmplus/tls/certbot/live/npm-15 -czhf - fullchain.pem privkey.pem
```

and the client just reads its stdout:

```diff
-rsync -aL --delete -e 'ssh -o BatchMode=yes' "${SRC_HOST}:${SRC_PATH}/" "${WORK}/new/"
+ssh -o BatchMode=yes -i "${SSH_KEY}" "${SRC_HOST}" | tar -xzf - -C "${WORK}/new"
```

Alpine is the trigger, but this is better regardless of platform. `rrsync` exists to *safely parse client-supplied rsync flags* — a fixed command has no such surface, because the far side decides entirely what gets sent and the client's command line is ignored.

Two things fall out of it:

- **`tar -h` dereferences the `live/` symlinks server-side.** More direct than `rsync -L` doing it from the client, and it removes the reason the rrsync root had to be widened to the *parent* of `live/` just to reach the `archive/` targets.
- **The certificate ID moves to one host.** It now lives in the export script rather than in `SRC_PATH` on every node, so recreating the cert in NPMplus (`npm-16`, `npm-17`…) is a one-place change.

Everything downstream is untouched: emptiness check, `cmp` change detection, PKCS#12 conversion, atomic rename.

## README

Gains the Alpine specifics — OpenSSH confirmed running, `restrict` available since it's not Dropbear — plus key generation, and two things worth being explicit about:

- **Append to `authorized_keys`, don't overwrite.** The key can never open a shell, so replacing an existing key rather than joining it costs SSH shell access to the LXC, with `pct enter` as the only way back.
- **A check that the forced command is actually in effect.** `ssh -i <key> root@npmplus 'echo hello'` must emit the tarball and ignore the command. If it prints `hello`, that key has a full root shell.

Shellcheck-clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_