### PR TITLE
fix(scripts): pass -T and document seeding known_hosts

### DIFF
--- a/scripts/technitium-cert-sync/README.md
+++ b/scripts/technitium-cert-sync/README.md
@@ -69,12 +69,34 @@ Verify from the node — both commands must produce the same tarball, because th
 forced command ignores whatever the client asks for:
 
 ```sh
-ssh -i /root/.ssh/technitium-cert-sync root@npmplus | tar -tzf -
-ssh -i /root/.ssh/technitium-cert-sync root@npmplus 'echo hello'
+ssh -T -i /root/.ssh/technitium-cert-sync root@npmplus | tar -tzf -
+ssh -T -i /root/.ssh/technitium-cert-sync root@npmplus 'echo hello'
 ```
 
 If the second prints `hello`, the forced command is not in effect and that key
 has a full root shell.
+
+Without `-T` you will also see `PTY allocation request failed on channel 0`.
+That is `restrict` refusing a terminal — the fetch still succeeds, and `-T`
+simply stops asking.
+
+### Seed known_hosts before enabling the timer
+
+The script runs `BatchMode=yes`, so an unknown host key is a hard failure rather
+than a prompt. Root's `known_hosts` must already trust NPMplus on **each** node
+before the timer runs unattended — the first interactive `ssh` does this, but
+only on the node where it was run:
+
+```sh
+ssh-keyscan -t ed25519 npmplus >> /root/.ssh/known_hosts
+```
+
+Compare the fingerprint against the one the other node already accepted rather
+than trusting whatever answers:
+
+```sh
+ssh-keygen -lf /root/.ssh/known_hosts -F npmplus
+```
 
 ## Install on each Technitium node
 

--- a/scripts/technitium-cert-sync/technitium-cert-sync.sh
+++ b/scripts/technitium-cert-sync/technitium-cert-sync.sh
@@ -31,7 +31,11 @@ main() {
     # The forced command tars the two PEMs to stdout with -h, so the symlinks
     # into ../../archive/ are dereferenced server-side and we receive real
     # files. Nothing here chooses what to fetch; the far side decides.
-    if ! ssh -o BatchMode=yes -i "${SSH_KEY}" "${SRC_HOST}" \
+    #
+    # -T because the key is restricted and would refuse a PTY anyway, and
+    # BatchMode so an unknown host key fails outright rather than hanging on a
+    # prompt no one will answer — see the known_hosts note in the README.
+    if ! ssh -T -o BatchMode=yes -i "${SSH_KEY}" "${SRC_HOST}" \
         | tar -xzf - -C "${WORK}/new"; then
         log "ERROR: could not fetch bundle from ${SRC_HOST}; leaving ${OUT} untouched"
         exit 1


### PR DESCRIPTION
Two fixes from actually running the fetch on `ns1`, before rolling it out to `ns2`. Follow-up to #1637.

## `-T` on the fetch

The verification run produced this alongside a successful fetch:

```
PTY allocation request failed on channel 0
Connection to npmplus closed.
fullchain.pem
privkey.pem
```

That's `restrict` refusing a terminal — working as intended, but ssh asked for one first. `-T` stops asking. Cosmetic in the systemd path (stdin isn't a tty there, so no PTY is requested anyway), but it makes the intent explicit and cleans up the interactive verification.

## The known_hosts prerequisite — the one likely to bite

The script runs `BatchMode=yes`, so an **unknown host key is a hard failure**, not a prompt. Accepting it interactively — as happened on `ns1` — seeds `known_hosts` on that node only.

So `ns2`'s timer would fail every hour, silently, until someone happened to SSH there by hand. And with 160h certificates, that's the kind of failure that surfaces as expired TLS about a week later rather than as an obvious error at install time.

README now covers it:

```sh
ssh-keyscan -t ed25519 npmplus >> /root/.ssh/known_hosts
ssh-keygen -lf /root/.ssh/known_hosts -F npmplus
```

The second command is there so the fingerprint can be compared against the one `ns1` already accepted, rather than trusting whatever answers the keyscan.

Shellcheck-clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_