### PR TITLE
fix(scripts): ProtectSystem=full made /etc read-only, breaking the write

### DIFF
--- a/scripts/technitium-cert-sync/README.md
+++ b/scripts/technitium-cert-sync/README.md
@@ -143,6 +143,17 @@ kdig -d +https @ns1.dns.vaderrp.com google.com    # DoH, port 443
   empty file it exits non-zero without touching `/etc/dns/ssl.pfx`, leaving the
   previous certificate in place until the next run. Failures surface in
   `journalctl -u technitium-cert-sync`.
-- **The `-legacy` OpenSSL flags** mirror the old in-cluster initContainer and
-  are known to produce a bundle Technitium accepts. Modern PKCS#12 defaults may
-  work on current .NET but have not been verified here.
+- **The `-legacy` OpenSSL flags** mirror the old in-cluster initContainer. They
+  are *not* required for the bundle to be readable — OpenSSL 3.5 on Debian 13
+  reads the result back without `-legacy` — so they are inherited caution rather
+  than a demonstrated need, and dropping them for modern defaults is untested
+  but plausible.
+- **The certificate has no Common Name.** Let's Encrypt's `shortlived` profile
+  omits it, so `openssl x509 -subject` prints an empty `subject=` and the SAN
+  extension is marked critical (which RFC 5280 requires when the subject is
+  empty). NPMplus' own compose file warns that "clients incorrectly requiring a
+  Certificate Common Name break when using certs from the shortlived/tlsserver
+  profile". If Technitium turns out to be one of them, set `ACME_PROFILE=classic`
+  on NPMplus for a 90-day certificate that carries a CN — which would also end
+  the six-day renewal treadmill, at the cost of applying to every NPMplus
+  certificate.

--- a/scripts/technitium-cert-sync/technitium-cert-sync.service
+++ b/scripts/technitium-cert-sync/technitium-cert-sync.service
@@ -9,8 +9,10 @@ Type=oneshot
 ExecStart=/usr/local/bin/technitium-cert-sync.sh
 
 # The bundle is written to /etc/dns and state kept in /var/lib; nothing else
-# needs to be writable.
-ProtectSystem=full
+# needs to be writable. ProtectSystem=full would mount /etc read-only and break
+# the write to /etc/dns/ssl.pfx, so use strict plus explicit ReadWritePaths.
+ProtectSystem=strict
+ReadWritePaths=/etc/dns /var/lib/technitium-cert
 ProtectHome=yes
 PrivateTmp=yes
 NoNewPrivileges=yes


### PR DESCRIPTION
`technitium-cert-sync.service` shows `failed` on `ns1`, and the unit could never have worked.

`ProtectSystem=full` mounts **`/etc` read-only** in addition to `/usr` and `/boot`. The script writes `/etc/dns/ssl.pfx`. So every run under systemd failed on the write, and the bundle currently present on both nodes came from running the script by hand.

```diff
-ProtectSystem=full
+ProtectSystem=strict
+ReadWritePaths=/etc/dns /var/lib/technitium-cert
```

`strict` with explicit `ReadWritePaths` is both correct and tighter than what `full` was meant to achieve — everything is read-only except the two paths that need writing.

## Two README corrections

Both are claims I stated with more confidence than they deserved.

**The `-legacy` flags were described as known-good.** They aren't required at all — OpenSSL 3.5 on Debian 13 reads the bundle back without them:

```
openssl pkcs12 -in /etc/dns/ssl.pfx -passin pass: -nokeys   # succeeds, no -legacy
```

So they're inherited caution from the old in-cluster initContainer rather than a demonstrated need, and they are *not* evidence that Technitium accepts the result.

**The certificate has no Common Name.** Verified on the live bundle:

```
subject=
notBefore=Jul 30 20:34:27 2026 GMT
notAfter=Aug  6 12:34:26 2026 GMT
X509v3 Subject Alternative Name: critical
    DNS:*.dns.vaderrp.com, DNS:dns.vaderrp.com, DNS:technitium.vaderrp.com
```

Empty subject, critical SAN — both are consequences of Let's Encrypt's `shortlived` profile, and RFC 5280 requires the SAN be critical when the subject is empty. NPMplus' own compose file warns that this profile breaks "clients incorrectly requiring a Certificate Common Name".

That's now the leading hypothesis for why Technitium starts its `:853` listener but presents nothing. Recorded in the README along with the fix if it's confirmed: `ACME_PROFILE=classic` gives a 90-day certificate carrying a CN, which would also end the six-day renewal treadmill — at the cost of applying to every NPMplus certificate.

Also confirmed by that output: the wildcard **did** issue, all three SANs are present, and the 160-hour lifetime is exactly as the profile docs describe.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_