### PR TITLE
fix(scripts): ProtectHome=yes hid /root/.ssh from the sync

### DIFF
--- a/scripts/technitium-cert-sync/README.md
+++ b/scripts/technitium-cert-sync/README.md
@@ -90,6 +90,12 @@ systemctl start technitium-cert-sync.service
 journalctl -u technitium-cert-sync.service -n 20
 ```
 
+Run it under systemd rather than by hand for the first test. The unit sandboxes
+the filesystem, so a script that works from a shell can still fail as a service
+— `ProtectHome` and `ProtectSystem` between them decide whether `/root/.ssh` and
+`/etc/dns` are even visible. A direct `./technitium-cert-sync.sh` proves
+nothing about whether the timer will work.
+
 Then in the Technitium admin UI, Settings → Optional Protocols:
 
 - **TLS Certificate File Path**: `/etc/dns/ssl.pfx`

--- a/scripts/technitium-cert-sync/technitium-cert-sync.service
+++ b/scripts/technitium-cert-sync/technitium-cert-sync.service
@@ -8,11 +8,20 @@ After=network-online.target
 Type=oneshot
 ExecStart=/usr/local/bin/technitium-cert-sync.sh
 
-# The bundle is written to /etc/dns and state kept in /var/lib; nothing else
-# needs to be writable. ProtectSystem=full would mount /etc read-only and break
-# the write to /etc/dns/ssl.pfx, so use strict plus explicit ReadWritePaths.
+# Everything read-only except the bundle's directory. ProtectSystem=full would
+# also mount /etc read-only and break the write to /etc/dns/ssl.pfx.
 ProtectSystem=strict
-ReadWritePaths=/etc/dns /var/lib/technitium-cert
-ProtectHome=yes
+ReadWritePaths=/etc/dns
+
+# Creates and owns /var/lib/technitium-cert. Using StateDirectory rather than
+# another ReadWritePaths entry matters: ReadWritePaths requires the path to
+# already exist or the unit fails to start its mount namespace.
+StateDirectory=technitium-cert
+
+# read-only, NOT yes. ProtectHome=yes makes /root an empty directory, which
+# hides both the SSH key and known_hosts — ssh then reports the identity file
+# missing and fails host key verification against files that plainly exist.
+ProtectHome=read-only
+
 PrivateTmp=yes
 NoNewPrivileges=yes


### PR DESCRIPTION
Follow-up to #1639. The unit still fails, now for a different sandboxing reason:

```
Identity file /root/.ssh/technitium-cert-sync not accessible: No such file or directory.
Host key verification failed.
```

against files that plainly exist:

```
-rw------- 1 root root 1101 Jul 31 01:56 known_hosts
-rw------- 1 root root  399 Jul 31 01:51 technitium-cert-sync
```

**`ProtectHome=yes` mounts `/root` as an empty directory.** ssh could see neither the key nor `known_hosts` — hence both errors at once, which is what makes it look baffling rather than like a permissions problem.

```diff
-ProtectHome=yes
+ProtectHome=read-only
```

Read-only is all the service needs: it reads both files and writes neither.

## Also: `StateDirectory` instead of a `ReadWritePaths` entry

```diff
-ReadWritePaths=/etc/dns /var/lib/technitium-cert
+ReadWritePaths=/etc/dns
+StateDirectory=technitium-cert
```

`ReadWritePaths` requires its paths to **already exist** or the unit fails setting up its mount namespace. `/var/lib/technitium-cert` only exists on `ns1` because the script was run by hand there — on `ns2` the previous version would have failed for this second, unrelated reason. `StateDirectory` creates and owns it.

## The pattern behind both bugs

This is the second sandboxing failure in this unit, after `ProtectSystem=full` made `/etc` read-only. Same root cause: **the script works from a shell and fails as a service**, because the sandbox decides which paths are visible at all — and the resulting errors describe missing files rather than a restricted namespace.

README now says to run the first test via `systemctl start` rather than invoking the script directly, since a direct run proves nothing about whether the timer will work. That would have caught both of these immediately.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_