### PR TITLE
fix(gatus): match certificate thresholds to 90-day certs

### DIFF
--- a/kubernetes/apps/observability/gatus/app/gatus-config.yaml
+++ b/kubernetes/apps/observability/gatus/app/gatus-config.yaml
@@ -67,9 +67,8 @@ endpoints:
       dns-resolver: tcp://1.1.1.1:53
     conditions:
       - "[DOMAIN_EXPIRATION] > 720h"
-      # NPMplus serves 7-day short-lived LE certs on the apex (max 168h
-      # lifetime, renewed around day 4-5) — alert only when renewal is overdue
-      - "[CERTIFICATE_EXPIRATION] > 48h"
+      # NPMplus is on ACME_PROFILE=classic, so this is a 90-day LE cert
+      - "[CERTIFICATE_EXPIRATION] > 240h"
     alerts:
       - type: ntfy
         send-on-resolved: true
@@ -105,17 +104,16 @@ endpoints:
         failure-threshold: 3
         success-threshold: 5
   # Technitium runs on LXCs outside the cluster and does not issue its own
-  # certificate — NPMplus does, and each node pulls the bundle from it. These
-  # checks exist to catch that pull breaking. NPMplus issues LE shortlived
-  # certs (160h, renewed around day 4-5), so 48h is the same threshold used on
-  # the apex above; the 240h used for 90-day certs would alert permanently.
+  # certificate — NPMplus does, and each node pulls the bundle from it hourly
+  # (scripts/technitium-cert-sync/). These checks exist to catch that pull
+  # breaking, which is otherwise invisible until DoT stops working.
   - name: technitium ns1 DoT certificate
     group: Network
     url: "tls://192.168.7.8:853"
     interval: 1h
     conditions:
       - "[CONNECTED] == true"
-      - "[CERTIFICATE_EXPIRATION] > 48h"
+      - "[CERTIFICATE_EXPIRATION] > 240h"
     alerts:
       - type: ntfy
         send-on-resolved: true
@@ -127,7 +125,7 @@ endpoints:
     interval: 1h
     conditions:
       - "[CONNECTED] == true"
-      - "[CERTIFICATE_EXPIRATION] > 48h"
+      - "[CERTIFICATE_EXPIRATION] > 240h"
     alerts:
       - type: ntfy
         send-on-resolved: true

--- a/scripts/technitium-cert-sync/README.md
+++ b/scripts/technitium-cert-sync/README.md
@@ -161,12 +161,13 @@ kdig -d +https @ns1.dns.vaderrp.com google.com    # DoH, port 443
 
 ## Failure modes
 
-- **A broken pull is invisible from the outside.** NPMplus issues Let's Encrypt
-  *shortlived* certificates — 160 hours, renewed around day 4–5 — so a node
-  stops serving a valid certificate within about a week of the sync breaking,
-  not the 90 days a classic certificate would give. The Gatus checks on `:853`
-  in `kubernetes/apps/observability/gatus/` exist for exactly this and are the
-  reason a `48h` threshold is used rather than `240h`.
+- **A broken pull is invisible from the outside.** Nothing about a node serving
+  a stale certificate looks wrong until it expires and clients start refusing
+  the handshake. The Gatus checks on `:853` in
+  `kubernetes/apps/observability/gatus/` exist for exactly this, with a `240h`
+  threshold matched to NPMplus running `ACME_PROFILE=classic` (90-day certs).
+  If that profile ever changes back to `shortlived`, those thresholds have to
+  come down with it — `240h` against a 160-hour certificate alerts permanently.
 - **The script never clobbers a good bundle.** If the fetch fails or returns an
   empty file it exits non-zero without touching `/etc/dns/ssl.pfx`, leaving the
   previous certificate in place until the next run. Failures surface in


### PR DESCRIPTION
NPMplus is on `ACME_PROFILE=classic` and all three of its certificates have now been renewed onto it, so everything it serves is 90-day rather than the 160-hour `shortlived` ones the current thresholds were written for.

Three thresholds go from `48h` to `240h`:

| Check | Why |
|---|---|
| `technitium ns1 DoT certificate` | mine, added in #1635 for shortlived certs |
| `technitium ns2 DoT certificate` | same |
| `vaderrp.com domain and expiration` | yours — see below |

`48h` against a 90-day certificate fires two days before expiry, which is no useful warning at all. The whole point of these checks is catching a broken renewal or a broken sync with time to act.

## On the apex check

That one carried a deliberate comment:

```yaml
# NPMplus serves 7-day short-lived LE certs on the apex (max 168h
# lifetime, renewed around day 4-5) — alert only when renewal is overdue
```

The reasoning was correct when written and no longer applies, so the comment would have actively misled whoever read it next. Replaced rather than just retuned. Shout if you'd rather keep the tighter threshold there for some reason I've missed.

## Unchanged

`erinko.fi mail certificate` and `shadowmorph.info` already used `240h`. Worth noting `erinko.fi` was briefly alerting against a shortlived cert — a `240h` threshold on a 160-hour certificate can never pass — and is correct again now that it has been renewed onto classic.

## Coupling worth remembering

The sync README's failure-mode note argued for `48h` on shortlived grounds and is rewritten. It now records the dependency explicitly: **if NPMplus ever goes back to `shortlived`, these thresholds have to come down with it**, or every certificate check alerts permanently.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_