### PR TITLE
feat(scripts): Keepalived VIP for the Technitium pair

### DIFF
--- a/scripts/technitium-keepalived/README.md
+++ b/scripts/technitium-keepalived/README.md
@@ -257,68 +257,42 @@ setup is exactly as it was — nothing here changes Technitium's own
 configuration.
 
 ---
+## Access from outside the house
 
-## Optional: exposing encrypted DNS to the internet
+**Decided: VPN only (UniFi Teleport). No port forwarding.**
 
-Forwarding `853` and `443` at the UDM to the VIP gives you DoT/DoQ/DoH from
-outside the house. It works, and the VIP is the right forward target since it
-follows whichever node is alive. But read this section before doing it.
+Forwarding `853`/`443` at the UDM to the VIP would work, but a split-horizon
+resolver is a poor thing to expose, for a reason that is easy to miss:
 
-### The problem nobody warns you about
+> **Recursion ACLs do not protect authoritative zones.** Technitium's "Allow
+> Recursion Only For Private Networks" governs *recursive* lookups. The internal
+> `vaderrp.com` zone is **authoritative**, and authoritative answers are served
+> to anyone who asks, ACL or not.
 
-**Recursion ACLs do not protect authoritative zones.** Technitium's "Allow
-Recursion Only For Private Networks" governs *recursive* lookups. Your internal
-`vaderrp.com` zone is **authoritative**, and authoritative answers are served to
-anyone who asks, ACL or not.
-
-So a public DoT endpoint would let anyone resolve `sonarr.vaderrp.com`,
+So a public DoT endpoint would resolve `sonarr.vaderrp.com`,
 `harbor.vaderrp.com`, `proxmox.vaderrp.com` and the rest straight to their
-internal addresses — your entire service inventory and IP layout, queryable by
-anyone who can guess a hostname. And the endpoint is discoverable: the
-certificate's SANs are in public Certificate Transparency logs.
+internal addresses — the whole service inventory and IP layout, to anyone who
+can guess a hostname. The endpoint is not obscure either: the certificate's SANs
+are in public Certificate Transparency logs.
 
-Fix this **before** opening the ports, via **Zones → vaderrp.com → Options →
-Query Access**, set to private networks only. Verify from outside afterwards:
+Fixing that means per-zone **Query Access** restrictions, plus QPM rate limiting
+for the open-resolver side, plus never forwarding `53`. A VPN gets encrypted DNS
+*and* internal name resolution with none of it, so that is the path taken.
 
-```sh
-kdig +tls @<your-wan-ip> sonarr.vaderrp.com     # must REFUSE or return nothing
-kdig +tls @<your-wan-ip> google.com             # this is what should work
-```
+### What this means in practice
 
-### The other trade
+Teleport clients arrive on the LAN, so nothing special is needed — split-horizon
+already resolves `dns.vaderrp.com` to `192.168.7.7` for them, and the
+certificate covers that name. Setting **UDM DHCP option 6 to `.7`** generally
+covers VPN clients too; confirm on the phone with a lookup once connected.
 
-Allowing recursion for public clients makes this an open resolver. A roaming
-phone has no fixed address, so there is no ACL that admits you and excludes
-everyone else, and Technitium has no per-client authentication for DNS.
+### One gotcha worth knowing
 
-It is a milder problem than it sounds — DoT, DoQ and DoH all require a
-handshake, so none of them can be used for the spoofed-source reflection
-amplification that makes open UDP/53 resolvers dangerous. What remains is
-resource consumption and strangers using your resolver.
+**Do not set Android's Private DNS to `dns.vaderrp.com` permanently.** That
+setting is system-wide and applies whether or not Teleport is connected, and it
+**fails closed** — with no public record for the name and no route to `.7`, DNS
+breaks entirely rather than falling back. Leave Private DNS on Automatic and let
+the VPN supply the resolver.
 
-Mitigate with **Settings → General → QPM Limit**, which rate limits per client
-subnet.
-
-### If you would rather not
-
-A VPN back home — Tailscale, or WireGuard on the UDM — gives roaming clients
-encrypted DNS *and* internal name resolution with nothing exposed, and sidesteps
-both problems above entirely. Worth weighing, given the only thing public
-exposure buys over it is not having to run a VPN client.
-
-### If you go ahead
-
-- **Forward only `853/tcp`, `853/udp`, `443/tcp`, `443/udp`.** Never forward
-  `53` in either protocol — that *is* exploitable for reflection amplification.
-- **Check `443/tcp` is not already forwarded** to something else. Public web
-  traffic goes through the Cloudflare tunnel rather than a port forward, so it
-  should be clear, but confirm.
-- **The public record must be DNS-only, not proxied.** In Cloudflare, an A
-  record for `dns.vaderrp.com` → your WAN IP with the grey cloud. Orange-cloud
-  proxying does not carry `853` at all, and on `443` it would terminate TLS with
-  Cloudflare's certificate and break DoH3.
-- **Split-horizon still applies**, and correctly: internal clients get `.7` from
-  Technitium, external clients get the WAN IP from Cloudflare. Same name, right
-  answer on both sides.
-- **Watch your WAN IP** if it is dynamic — the public record needs DDNS or it
-  will silently point at somebody else's address.
+The same reasoning applies to any DoT client configured by hostname on a device
+that leaves the network.

--- a/scripts/technitium-keepalived/README.md
+++ b/scripts/technitium-keepalived/README.md
@@ -1,0 +1,324 @@
+# Technitium DNS VIP — Keepalived setup
+
+Floats `192.168.7.7` between the two Technitium LXCs so the UDM can hand out one
+DNS address instead of two, and so failover takes ~3 seconds rather than a
+stub-resolver timeout.
+
+| | |
+|---|---|
+| VIP | `192.168.7.7` |
+| `ns1` | LXC 118 on `meanie`, `192.168.7.8`, Technitium **primary**, VRRP **MASTER** |
+| `ns2` | LXC 100 on the NUC, `192.168.7.9`, Technitium secondary, VRRP BACKUP |
+
+VRRP MASTER is on `ns1` so the VIP normally sits with the Technitium primary —
+the node that is also the RFC2136 target for external-dns.
+
+Design rationale:
+[`docs/networking/technitium-dns-ha.md`](../../docs/networking/technitium-dns-ha.md) §6.
+
+---
+
+## Before you start
+
+Five checks. The first two are the ones that ruin your afternoon if skipped.
+
+### 1. Is VRID 53 already in use on this segment?
+
+Two VRRP pairs sharing a VRID on the same L2 will fight over the same virtual
+MAC. Watch for a minute on either node:
+
+```sh
+timeout 60 tcpdump -i eth0 -n 'proto 112'
+```
+
+Silence means 53 is free. If anything appears, note its VRID from the output and
+pick a different number in both config files. The UDM is the likely candidate if
+it has any redundancy configured.
+
+### 2. Is `192.168.7.7` actually free?
+
+```sh
+ping -c3 192.168.7.7          # should fail
+arping -c3 -I eth0 192.168.7.7  # should get no reply
+```
+
+It should be free — it survives only in `archive/` as Technitium's old Cilium
+LB-IPAM address. Note it *does* fall inside the Cilium `static-pool` block
+`192.168.7.0/25`, so it is worth treating as reserved: Cilium will not
+auto-assign it, but a Service could still claim it by hand.
+
+### 3. Does the LXC have the capabilities keepalived needs?
+
+VRRP needs raw sockets and the ability to add an address. Unprivileged Proxmox
+containers keep `CAP_NET_ADMIN` and `CAP_NET_RAW` by default, but confirm rather
+than assume:
+
+```sh
+capsh --print | grep -oE 'cap_net_admin|cap_net_raw'
+```
+
+Both should appear. If not, add to the container config on the Proxmox host:
+
+```
+lxc.cap.keep = net_admin net_raw
+```
+
+### 4. Is `dig` installed?
+
+The health check needs it:
+
+```sh
+command -v dig || apt install -y bind9-dnsutils
+```
+
+### 5. Is Technitium listening on all addresses?
+
+This is the one that silently produces a VIP that answers nothing. In the admin
+UI, **Settings → General → DNS Server Local End Points** must be `0.0.0.0:53`
+(and `[::]:53`) rather than a list of specific addresses — otherwise the server
+will not answer on `.7` when the VIP lands.
+
+Confirm the interface name is `eth0` while you are there:
+
+```sh
+ip -brief addr
+```
+
+---
+
+## 1. Install keepalived on both nodes
+
+```sh
+apt update && apt install -y keepalived
+```
+
+Do not enable it yet — the shipped config is empty and starting it now just
+produces noise.
+
+## 2. Install the health check
+
+On **both** nodes:
+
+```sh
+install -m 0755 -o root -g root check-technitium-dns.sh /usr/local/bin/
+/usr/local/bin/check-technitium-dns.sh && echo "check passes"
+```
+
+Root ownership and `0755` matter: `enable_script_security` makes keepalived
+refuse to run a script that is writable by anyone else.
+
+The check queries `vaderrp.com SOA` against `127.0.0.1` — a locally
+authoritative name, chosen so an internet outage does not move the VIP. Both
+nodes would be equally unable to resolve upstream, and moving it would help
+nobody.
+
+## 3. Install the configs
+
+Pick an auth password of **8 characters or fewer** — VRRPv2 truncates beyond
+that, and a silent truncation mismatch is a miserable thing to debug. It is not
+a security control, just a guard against a VRID collision with something
+unrelated.
+
+```sh
+# on ns1
+install -m 0600 keepalived-ns1.conf /etc/keepalived/keepalived.conf
+# on ns2
+install -m 0600 keepalived-ns2.conf /etc/keepalived/keepalived.conf
+
+# then on both, replace CHANGEME with the same value
+sed -i 's/CHANGEME/<yourpass>/' /etc/keepalived/keepalived.conf
+```
+
+## 4. Bring it up — ns1 first
+
+```sh
+systemctl enable --now keepalived
+systemctl status keepalived --no-pager
+ip -brief addr show eth0
+```
+
+`ip addr` should now show **both** `192.168.7.8` and `192.168.7.7` on `eth0`.
+The journal should show the instance entering MASTER state:
+
+```sh
+journalctl -u keepalived -n 30 --no-pager
+```
+
+Then confirm the VIP actually serves DNS, which is the thing that matters:
+
+```sh
+dig @192.168.7.7 vaderrp.com SOA +short
+```
+
+If the address is up but this returns nothing, revisit pre-flight check 5.
+
+## 5. Bring up ns2
+
+```sh
+systemctl enable --now keepalived
+ip -brief addr show eth0     # should NOT have .7
+journalctl -u keepalived -n 30 --no-pager
+```
+
+`ns2` must stay in BACKUP state and must **not** hold the VIP. If both nodes
+have `.7`, they cannot see each other's advertisements — check that `auth_pass`
+matches exactly, that the unicast addresses are the right way round, and that
+nothing is filtering IP protocol 112 between them.
+
+## 6. Test failover
+
+Three separate failure modes. Test all three — they exercise different paths.
+
+**Keepalived stops** (clean handover):
+
+```sh
+# ns1
+systemctl stop keepalived
+# ns2 — .7 should appear within ~3s
+ip -brief addr show eth0
+dig @192.168.7.7 vaderrp.com SOA +short
+# ns1 — restore, VIP should come back
+systemctl start keepalived
+```
+
+**Technitium dies but the host lives** — this is the one a plain VRRP setup
+misses and the `vrrp_script` exists for:
+
+```sh
+# ns1
+systemctl stop technitium
+# within ~10s (interval 5, fall 2) ns2 should take the VIP
+# ns1
+systemctl start technitium
+```
+
+**The whole node disappears:**
+
+```sh
+# from the Proxmox host
+pct stop 118
+```
+
+Watch from a third machine throughout:
+
+```sh
+while true; do dig @192.168.7.7 vaderrp.com SOA +short | head -1; sleep 1; done
+```
+
+A gap of a second or two during handover is expected. A gap that does not
+recover is not.
+
+## 7. Point things at it
+
+- **DNS records.** `dns.vaderrp.com` A → `192.168.7.7`. Also move
+  `technitium.vaderrp.com` from `.8` to `.7` if you want the admin UI to follow
+  the VIP — the certificate covers both names.
+- **UDM DHCP option 6** → `.7` only. This is the original goal: one address for
+  clients you cannot conveniently hand two.
+- **Leave `machine.network.nameservers` and the CoreDNS forward list on the real
+  IPs.** Two entries cost nothing there and are strictly more robust than
+  depending on VRRP. Only DHCP clients need the VIP.
+- **Leave `--rfc2136-host` at `192.168.7.8`.** Dynamic updates must reach the
+  cluster *primary*, not whichever node happens to hold the VIP.
+
+## 8. Monitoring
+
+Add to `kubernetes/apps/observability/gatus/app/gatus-config.yaml` once the VIP
+is live — not before, or it alerts on something that does not exist yet:
+
+```yaml
+  - name: technitium VIP
+    group: Network
+    url: "192.168.7.7"
+    interval: 1m
+    dns:
+      query-name: "vaderrp.com"
+      query-type: "SOA"
+    conditions:
+      - "[DNS_RCODE] == NOERROR"
+    alerts:
+      - type: ntfy
+        send-on-resolved: true
+        failure-threshold: 3
+        success-threshold: 5
+```
+
+This catches the case the per-node checks cannot: both nodes healthy, but the
+VIP held by nobody.
+
+## Rollback
+
+```sh
+systemctl disable --now keepalived     # on both nodes
+```
+
+The address disappears with the daemon. Revert UDM DHCP to `.8`/`.9` and the
+setup is exactly as it was — nothing here changes Technitium's own
+configuration.
+
+---
+
+## Optional: exposing encrypted DNS to the internet
+
+Forwarding `853` and `443` at the UDM to the VIP gives you DoT/DoQ/DoH from
+outside the house. It works, and the VIP is the right forward target since it
+follows whichever node is alive. But read this section before doing it.
+
+### The problem nobody warns you about
+
+**Recursion ACLs do not protect authoritative zones.** Technitium's "Allow
+Recursion Only For Private Networks" governs *recursive* lookups. Your internal
+`vaderrp.com` zone is **authoritative**, and authoritative answers are served to
+anyone who asks, ACL or not.
+
+So a public DoT endpoint would let anyone resolve `sonarr.vaderrp.com`,
+`harbor.vaderrp.com`, `proxmox.vaderrp.com` and the rest straight to their
+internal addresses — your entire service inventory and IP layout, queryable by
+anyone who can guess a hostname. And the endpoint is discoverable: the
+certificate's SANs are in public Certificate Transparency logs.
+
+Fix this **before** opening the ports, via **Zones → vaderrp.com → Options →
+Query Access**, set to private networks only. Verify from outside afterwards:
+
+```sh
+kdig +tls @<your-wan-ip> sonarr.vaderrp.com     # must REFUSE or return nothing
+kdig +tls @<your-wan-ip> google.com             # this is what should work
+```
+
+### The other trade
+
+Allowing recursion for public clients makes this an open resolver. A roaming
+phone has no fixed address, so there is no ACL that admits you and excludes
+everyone else, and Technitium has no per-client authentication for DNS.
+
+It is a milder problem than it sounds — DoT, DoQ and DoH all require a
+handshake, so none of them can be used for the spoofed-source reflection
+amplification that makes open UDP/53 resolvers dangerous. What remains is
+resource consumption and strangers using your resolver.
+
+Mitigate with **Settings → General → QPM Limit**, which rate limits per client
+subnet.
+
+### If you would rather not
+
+A VPN back home — Tailscale, or WireGuard on the UDM — gives roaming clients
+encrypted DNS *and* internal name resolution with nothing exposed, and sidesteps
+both problems above entirely. Worth weighing, given the only thing public
+exposure buys over it is not having to run a VPN client.
+
+### If you go ahead
+
+- **Forward only `853/tcp`, `853/udp`, `443/tcp`, `443/udp`.** Never forward
+  `53` in either protocol — that *is* exploitable for reflection amplification.
+- **Check `443/tcp` is not already forwarded** to something else. Public web
+  traffic goes through the Cloudflare tunnel rather than a port forward, so it
+  should be clear, but confirm.
+- **The public record must be DNS-only, not proxied.** In Cloudflare, an A
+  record for `dns.vaderrp.com` → your WAN IP with the grey cloud. Orange-cloud
+  proxying does not carry `853` at all, and on `443` it would terminate TLS with
+  Cloudflare's certificate and break DoH3.
+- **Split-horizon still applies**, and correctly: internal clients get `.7` from
+  Technitium, external clients get the WAN IP from Cloudflare. Same name, right
+  answer on both sides.
+- **Watch your WAN IP** if it is dynamic — the public record needs DDNS or it
+  will silently point at somebody else's address.

--- a/scripts/technitium-keepalived/check-technitium-dns.sh
+++ b/scripts/technitium-keepalived/check-technitium-dns.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Health check for keepalived's vrrp_script. Exit 0 while Technitium is
+# answering, non-zero when it is not.
+#
+# Queries a *locally authoritative* name deliberately. Checking something like
+# google.com would move the VIP during an internet outage, when both nodes are
+# equally unable to resolve and moving it helps nobody.
+set -Eeuo pipefail
+
+readonly ZONE="${ZONE:-vaderrp.com}"
+
+# dig exits non-zero on timeout, which set -e would turn into an unhelpful
+# early exit — take the output and let the emptiness test decide instead.
+answer="$(dig +short +time=2 +tries=1 @127.0.0.1 "${ZONE}" SOA 2>/dev/null || true)"
+
+[[ -n "${answer}" ]]

--- a/scripts/technitium-keepalived/keepalived-ns1.conf
+++ b/scripts/technitium-keepalived/keepalived-ns1.conf
@@ -1,0 +1,57 @@
+! /etc/keepalived/keepalived.conf on ns1 (LXC 118, meanie, 192.168.7.8)
+!
+! ns1 is the Technitium cluster primary and the VRRP MASTER, so the VIP
+! normally sits on the node that is also the RFC2136 target.
+
+global_defs {
+    router_id ns1
+
+    ! keepalived will not run a script as root unless script security is
+    ! enabled and the script is root-owned and not writable by anyone else.
+    enable_script_security
+    script_user root
+}
+
+vrrp_script chk_technitium {
+    script "/usr/local/bin/check-technitium-dns.sh"
+    interval 5
+    timeout 3
+    rise 2
+    fall 2
+    ! 150 - 60 = 90, below ns2's 100, so Technitium dying here hands the VIP
+    ! over even though the host itself is still up. A weight rather than a
+    ! hard fault so the node recovers on its own when the check passes again.
+    weight -60
+}
+
+vrrp_instance DNS_VIP {
+    state MASTER
+    interface eth0
+    virtual_router_id 53
+    priority 150
+    advert_int 1
+
+    ! Unicast rather than multicast. The two nodes sit on different physical
+    ! hosts, so VRRP crosses the switch fabric — unicast removes IGMP snooping
+    ! and multicast forwarding from the list of things that can break this.
+    unicast_src_ip 192.168.7.8
+    unicast_peer {
+        192.168.7.9
+    }
+
+    ! VRRPv2 auth is plaintext and capped at 8 characters. It is not a security
+    ! control; it stops an unrelated VRRP pair on the same segment from
+    ! interfering if a VRID ever collides.
+    authentication {
+        auth_type PASS
+        auth_pass CHANGEME
+    }
+
+    virtual_ipaddress {
+        192.168.7.7/24 dev eth0
+    }
+
+    track_script {
+        chk_technitium
+    }
+}

--- a/scripts/technitium-keepalived/keepalived-ns2.conf
+++ b/scripts/technitium-keepalived/keepalived-ns2.conf
@@ -1,0 +1,49 @@
+! /etc/keepalived/keepalived.conf on ns2 (LXC 100, NUC, 192.168.7.9)
+!
+! Identical to ns1 apart from state, priority and the unicast addresses.
+! auth_pass must match ns1 exactly or the two will not see each other.
+
+global_defs {
+    router_id ns2
+
+    enable_script_security
+    script_user root
+}
+
+vrrp_script chk_technitium {
+    script "/usr/local/bin/check-technitium-dns.sh"
+    interval 5
+    timeout 3
+    rise 2
+    fall 2
+    ! Harmless here: 100 - 60 = 40 is still below ns1's 150, so a failing check
+    ! on the backup changes nothing. It matters only if ns1 is already down,
+    ! where it correctly stops ns2 claiming a VIP it cannot serve.
+    weight -60
+}
+
+vrrp_instance DNS_VIP {
+    state BACKUP
+    interface eth0
+    virtual_router_id 53
+    priority 100
+    advert_int 1
+
+    unicast_src_ip 192.168.7.9
+    unicast_peer {
+        192.168.7.8
+    }
+
+    authentication {
+        auth_type PASS
+        auth_pass CHANGEME
+    }
+
+    virtual_ipaddress {
+        192.168.7.7/24 dev eth0
+    }
+
+    track_script {
+        chk_technitium
+    }
+}


### PR DESCRIPTION
The last piece — floats `192.168.7.7` between the two Technitium LXCs so the UDM hands out one DNS address instead of two, and failover takes ~3 seconds rather than a stub-resolver timeout.

Nothing here is applied by Flux; it's installed on the LXCs by hand per the README. Design rationale: #1633 §6.

| | |
|---|---|
| `ns1` | LXC 118, `meanie`, `.8`, Technitium **primary**, VRRP **MASTER** |
| `ns2` | LXC 100, NUC, `.9`, secondary, VRRP BACKUP |

MASTER sits on `ns1` so the VIP normally rests with the Technitium primary — the same node external-dns targets for RFC2136.

## Choices worth flagging

**Unicast, not multicast.** The nodes are on different physical hosts, so VRRP crosses the switch fabric. Unicast removes IGMP snooping and multicast forwarding from the set of things that can break this, for two lines of config.

**The health check queries a locally authoritative name.** Checking something upstream would move the VIP during an internet outage — when both nodes are equally unable to resolve and moving it helps nobody. It's wired as a `weight` rather than a hard fault so a node recovers on its own once Technitium answers again.

That check is also the reason this beats plain VRRP: it catches the host being up while the DNS server is down, which is exactly the failure Proxmox HA couldn't see either (#1633 §1.5).

## Pre-flight checks are front-loaded

Five of them, two load-bearing:

- **VRID collision** on the segment — `tcpdump -i eth0 -n 'proto 112'` for a minute. Two pairs sharing a VRID fight over the same virtual MAC.
- **Technitium's Local End Points must be `0.0.0.0:53`**, not a list of specific addresses. Otherwise the VIP comes up perfectly and answers nothing.

Plus capability checks for the unprivileged LXC, `dig` availability, and confirming `.7` is genuinely free.

## Also: exposing encrypted DNS publicly

Since that's the stated next step, the README covers it — and there's a hazard worth reading before touching the UDM.

**Recursion ACLs do not protect authoritative zones.** "Allow Recursion Only For Private Networks" governs *recursive* lookups. The internal `vaderrp.com` zone is **authoritative**, and authoritative answers go to anyone who asks.

So forwarding `853` without fixing this first would let anyone resolve `sonarr.vaderrp.com`, `harbor.vaderrp.com`, `proxmox.vaderrp.com` and the rest to their internal addresses — the whole service inventory and IP layout. The endpoint isn't obscure either: the certificate's SANs are in public CT logs.

The fix is per-zone **Query Access** set to private networks only, before the ports open, with a verification command from outside.

The README also covers the open-resolver trade (milder than it sounds — DoT/DoQ/DoH all require handshakes, so none can be used for spoofed-source reflection amplification), QPM rate limiting, never forwarding `53`, and why the Cloudflare record must be grey-cloud.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_