### PR TITLE
fix(scripts): keepalived health check could not fail

### DIFF
--- a/scripts/technitium-keepalived/README.md
+++ b/scripts/technitium-keepalived/README.md
@@ -101,7 +101,6 @@ On **both** nodes:
 
 ```sh
 install -m 0755 -o root -g root check-technitium-dns.sh /usr/local/bin/
-/usr/local/bin/check-technitium-dns.sh && echo "check passes"
 ```
 
 Root ownership and `0755` matter: `enable_script_security` makes keepalived
@@ -111,6 +110,30 @@ The check queries `vaderrp.com SOA` against `127.0.0.1` — a locally
 authoritative name, chosen so an internet outage does not move the VIP. Both
 nodes would be equally unable to resolve upstream, and moving it would help
 nobody.
+
+### Test it in both directions before trusting it
+
+A health check that passes when it should is half the test. The half that
+matters is whether it **fails** when it should — a check that cannot fail is
+worse than no check at all, because it looks like protection while the VIP sits
+on a dead server.
+
+```sh
+/usr/local/bin/check-technitium-dns.sh; echo "exit=$?"      # expect 0
+
+systemctl stop technitium
+/usr/local/bin/check-technitium-dns.sh; echo "exit=$?"      # expect 1
+systemctl start technitium
+```
+
+If the second returns `0`, stop and fix the check before going any further —
+everything downstream of it is decorative.
+
+This is not hypothetical. The first version of this script wrapped `dig` in
+`|| true`, discarding its exit code 9 for "no reply". Because dig writes
+`;; communications error ... connection refused` to *stdout* rather than stderr,
+the output was non-empty too, so both halves of the test passed against a server
+that was not running.
 
 ## 3. Install the configs
 
@@ -191,6 +214,18 @@ systemctl stop technitium
 # ns1
 systemctl start technitium
 ```
+
+If the VIP does **not** move, check in this order:
+
+1. `/usr/local/bin/check-technitium-dns.sh; echo "exit=$?"` — must be `1` while
+   Technitium is stopped. If it is `0`, the check is broken, not keepalived.
+2. `journalctl -u keepalived --since "5 min ago"` — look for
+   `VRRP_Script(chk_technitium) failed` and a priority change. Its absence means
+   keepalived is not acting on the script.
+3. `ls -ld /usr/local/bin` — Debian ships this `drwxrwsr-x root staff`, and
+   `enable_script_security` refuses to execute a script whose directory is
+   writable by non-root. If that is the problem, move the script to
+   `/etc/keepalived/` and update the `script` path in both configs.
 
 **The whole node disappears:**
 

--- a/scripts/technitium-keepalived/README.md
+++ b/scripts/technitium-keepalived/README.md
@@ -100,11 +100,15 @@ produces noise.
 On **both** nodes:
 
 ```sh
-install -m 0755 -o root -g root check-technitium-dns.sh /usr/local/bin/
+install -m 0755 -o root -g root check-technitium-dns.sh /etc/keepalived/
 ```
 
-Root ownership and `0755` matter: `enable_script_security` makes keepalived
-refuse to run a script that is writable by anyone else.
+**`/etc/keepalived/`, not `/usr/local/bin/`.** Debian ships the latter as
+`drwxrwsr-x root staff` — group-writable — and `enable_script_security` refuses
+to execute a script whose directory anyone but root can write to, since a
+`staff` member could swap it out from under a daemon running it as root.
+`/etc/keepalived/` is `root:root`, and keeping the script beside the config that
+references it is tidier anyway.
 
 The check queries `vaderrp.com SOA` against `127.0.0.1` — a locally
 authoritative name, chosen so an internet outage does not move the VIP. Both
@@ -119,10 +123,10 @@ worse than no check at all, because it looks like protection while the VIP sits
 on a dead server.
 
 ```sh
-/usr/local/bin/check-technitium-dns.sh; echo "exit=$?"      # expect 0
+/etc/keepalived/check-technitium-dns.sh; echo "exit=$?"      # expect 0
 
 systemctl stop technitium
-/usr/local/bin/check-technitium-dns.sh; echo "exit=$?"      # expect 1
+/etc/keepalived/check-technitium-dns.sh; echo "exit=$?"      # expect 1
 systemctl start technitium
 ```
 
@@ -217,15 +221,15 @@ systemctl start technitium
 
 If the VIP does **not** move, check in this order:
 
-1. `/usr/local/bin/check-technitium-dns.sh; echo "exit=$?"` — must be `1` while
+1. `/etc/keepalived/check-technitium-dns.sh; echo "exit=$?"` — must be `1` while
    Technitium is stopped. If it is `0`, the check is broken, not keepalived.
 2. `journalctl -u keepalived --since "5 min ago"` — look for
    `VRRP_Script(chk_technitium) failed` and a priority change. Its absence means
    keepalived is not acting on the script.
-3. `ls -ld /usr/local/bin` — Debian ships this `drwxrwsr-x root staff`, and
-   `enable_script_security` refuses to execute a script whose directory is
-   writable by non-root. If that is the problem, move the script to
-   `/etc/keepalived/` and update the `script` path in both configs.
+3. `ls -ld "$(dirname /etc/keepalived/check-technitium-dns.sh)"` — the directory
+   must not be writable by anyone but root, or `enable_script_security` silently
+   declines to run the script. This is why it lives in `/etc/keepalived/` rather
+   than `/usr/local/bin/` (step 2).
 
 **The whole node disappears:**
 

--- a/scripts/technitium-keepalived/check-technitium-dns.sh
+++ b/scripts/technitium-keepalived/check-technitium-dns.sh
@@ -9,8 +9,18 @@ set -Eeuo pipefail
 
 readonly ZONE="${ZONE:-vaderrp.com}"
 
-# dig exits non-zero on timeout, which set -e would turn into an unhelpful
-# early exit — take the output and let the emptiness test decide instead.
-answer="$(dig +short +time=2 +tries=1 @127.0.0.1 "${ZONE}" SOA 2>/dev/null || true)"
+# Two independent tests, because either alone has been wrong here before.
+#
+# dig exits 9 when it gets no reply. An earlier version of this script wrapped
+# the call in `|| true`, which discarded that — and because dig writes
+# "communications error ... connection refused" to *stdout*, the output was
+# non-empty too. Both halves of the test passed against a server that was not
+# running, so the VIP never moved. A health check that cannot fail is worse
+# than no health check.
+if ! out="$(dig +short +time=2 +tries=1 @127.0.0.1 "${ZONE}" SOA 2>/dev/null)"; then
+    exit 1
+fi
 
-[[ -n "${answer}" ]]
+# A real SOA answer begins with the MNAME — a hostname ending in a dot. This
+# rejects dig's own diagnostics, which begin with ';'.
+grep -qE '^[A-Za-z0-9_.-]+\.[[:space:]]' <<<"${out}"

--- a/scripts/technitium-keepalived/keepalived-ns1.conf
+++ b/scripts/technitium-keepalived/keepalived-ns1.conf
@@ -13,7 +13,7 @@ global_defs {
 }
 
 vrrp_script chk_technitium {
-    script "/usr/local/bin/check-technitium-dns.sh"
+    script "/etc/keepalived/check-technitium-dns.sh"
     interval 5
     timeout 3
     rise 2

--- a/scripts/technitium-keepalived/keepalived-ns2.conf
+++ b/scripts/technitium-keepalived/keepalived-ns2.conf
@@ -11,7 +11,7 @@ global_defs {
 }
 
 vrrp_script chk_technitium {
-    script "/usr/local/bin/check-technitium-dns.sh"
+    script "/etc/keepalived/check-technitium-dns.sh"
     interval 5
     timeout 3
     rise 2


### PR DESCRIPTION
The health check reported healthy against a **stopped** Technitium, so stopping the DNS server never moved the VIP — the exact failure the `vrrp_script` exists to catch, and the reason Proxmox HA was ruled out in #1633 §1.5.

Confirmed on ns1: `technitium` inactive, nothing listening on `:53`, no stray process, and the check still returned `exit=0`.

## Two mistakes compounded

```sh
answer="$(dig +short ... 2>/dev/null || true)"
[[ -n "${answer}" ]]
```

- **`|| true` discarded dig's exit code**, which is `9` for "no reply".
- **dig writes `;; communications error ... connection refused` to *stdout***, not stderr — so the captured output was non-empty too.

Both halves of the test passed against a server that wasn't running.

Reproduced with a stub before and after:

```
=== server DOWN (should be non-zero) ===
  old logic exit=0
  new logic exit=1
=== server UP (should be zero) ===
  new logic exit=0
```

The fix checks dig's exit status, and separately requires the output to look like an SOA answer — a hostname followed by whitespace, which dig's diagnostics can't match since they start with `;`. Either test alone would have caught this; both are free.

## The README change matters more

It previously said to verify the check *passes*. It never said to verify it *fails*, which is the half that counts — **a check that cannot fail is worse than no check**, because it looks like protection while the VIP sits on a dead server.

Now there's an explicit both-directions test, plus a troubleshooting order for when the VIP doesn't move.

## Script moves to `/etc/keepalived/`

Also fixes a contradiction in the original instructions: I enabled `enable_script_security` *and* told you to install into `/usr/local/bin`, which Debian ships as `drwxrwsr-x root staff`. keepalived refuses to execute a script from a directory writable by non-root, since a `staff` member could swap it out from under a daemon running it as root.

`/etc/keepalived/` is `root:root` and keeps the script beside the config referencing it. This matches what's already deployed on both nodes.

---

**After merging, the corrected script still needs copying to both nodes** — moving the old one didn't change its logic. Then re-run the Technitium-stop test; it should return `exit=1` and the VIP should move within ~10s.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_