### PR TITLE
feat(gatus): monitor the Technitium Keepalived VIP

### DIFF
--- a/kubernetes/apps/observability/gatus/app/gatus-config.yaml
+++ b/kubernetes/apps/observability/gatus/app/gatus-config.yaml
@@ -131,3 +131,25 @@ endpoints:
         send-on-resolved: true
         failure-threshold: 3
         success-threshold: 5
+  # The Keepalived VIP (scripts/technitium-keepalived/). This catches the one
+  # failure the per-node checks structurally cannot: both nodes healthy, but the
+  # VIP held by nobody — a VRRP misconfiguration, a partition where each node
+  # thinks the other owns it, or keepalived simply not running on either.
+  #
+  # Queries a locally authoritative name rather than a recursive one, matching
+  # the vrrp_script's reasoning: an upstream outage should not alert here, since
+  # the VIP itself would be fine and there is nothing to fail over to.
+  - name: technitium VIP
+    group: Network
+    url: "192.168.7.7"
+    interval: 1m
+    dns:
+      query-name: "vaderrp.com"
+      query-type: "SOA"
+    conditions:
+      - "[DNS_RCODE] == NOERROR"
+    alerts:
+      - type: ntfy
+        send-on-resolved: true
+        failure-threshold: 3
+        success-threshold: 5


### PR DESCRIPTION
Checks that `192.168.7.7` answers DNS, completing the monitoring for the VIP added in #1642.

```yaml
  - name: technitium VIP
    group: Network
    url: "192.168.7.7"
    interval: 1m
    dns:
      query-name: "vaderrp.com"
      query-type: "SOA"
    conditions:
      - "[DNS_RCODE] == NOERROR"
```

## Why this and not just the per-node checks

The existing `:853` checks watch `ns1` and `ns2` individually. They cannot see the failure where **both nodes are healthy but the VIP is held by nobody** — a VRRP misconfiguration, a partition where each node believes the other owns it, or keepalived simply not running on either. Every per-node check stays green while every DHCP client has no working resolver.

That's the failure worth catching, since after the DHCP change the VIP becomes the only resolver most clients have.

## Two deliberate choices

**Locally authoritative query**, not a recursive one. Same reasoning as the `vrrp_script`: an upstream outage shouldn't alert here, because the VIP itself would be fine and there'd be nothing to fail over to. A `SOA` for `vaderrp.com` is answered from the zone.

**1 minute rather than hourly.** The certificate checks are hourly because expiry moves slowly. This is a liveness check on the address most clients depend on, and a DNS query is cheap.

Verified the file parses and the three Network endpoints resolve as expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_