### PR TITLE
fix(gatus): address the DoT checks by hostname, not IP

### DIFF
--- a/kubernetes/apps/observability/gatus/app/gatus-config.yaml
+++ b/kubernetes/apps/observability/gatus/app/gatus-config.yaml
@@ -107,9 +107,15 @@ endpoints:
   # certificate — NPMplus does, and each node pulls the bundle from it hourly
   # (scripts/technitium-cert-sync/). These checks exist to catch that pull
   # breaking, which is otherwise invisible until DoT stops working.
+  #
+  # Addressed by hostname, not IP: the certificate carries only DNS SANs
+  # (*.dns.vaderrp.com, dns.vaderrp.com, technitium.vaderrp.com), so verifying
+  # against an IP fails with "doesn't contain any IP SANs" no matter how healthy
+  # the node is. The hostnames also make this the same code path a real DoT
+  # client takes.
   - name: technitium ns1 DoT certificate
     group: Network
-    url: "tls://192.168.7.8:853"
+    url: "tls://ns1.dns.vaderrp.com:853"
     interval: 1h
     conditions:
       - "[CONNECTED] == true"
@@ -121,7 +127,7 @@ endpoints:
         success-threshold: 5
   - name: technitium ns2 DoT certificate
     group: Network
-    url: "tls://192.168.7.9:853"
+    url: "tls://ns2.dns.vaderrp.com:853"
     interval: 1h
     conditions:
       - "[CONNECTED] == true"


### PR DESCRIPTION
Both Technitium DoT checks from #1635 are red:

```
tls: failed to verify certificate: x509: cannot validate certificate for
192.168.7.8 because it doesn't contain any IP SANs
```

The certificate carries only DNS SANs — `*.dns.vaderrp.com`, `dns.vaderrp.com`, `technitium.vaderrp.com` — so verifying it against an **IP literal** can never succeed, no matter how healthy the node is. I listed those SANs myself in #1633 §4.1 and still pointed the check at an address that can't match one. The checks were reporting on my URL, not on anything real.

```diff
-    url: "tls://192.168.7.8:853"
+    url: "tls://ns1.dns.vaderrp.com:853"
-    url: "tls://192.168.7.9:853"
+    url: "tls://ns2.dns.vaderrp.com:853"
```

Both names are covered by the wildcard and each resolves to its own node, so the per-node distinction the checks exist for is preserved. It also makes them take the same code path a real DoT client does — resolve, verify the chain, match the hostname — which is what you just confirmed by hand:

```
depth=0 CN=*.dns.vaderrp.com
verify return:1
```

The reason is now a comment in the config so nobody simplifies it back to IPs later.

## Note on the VIP check

Unaffected, and green throughout — it's a DNS query rather than a TLS handshake, so certificate naming never enters into it. Nice accident that the one check exercising a different mechanism was the one that stayed up.

## After merging

The two cards should go green within an hour (their interval). Worth confirming `ns1.dns.vaderrp.com` and `ns2.dns.vaderrp.com` have A records pointing at `.8`/`.9` respectively — the NS records in the `dns.vaderrp.com` zone reference both names, so glue should exist, but it's the one assumption this change rests on.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_