### PR TITLE
fix(external-dns): give records a cacheable TTL and stop the rewrite loop

### DIFF
--- a/kubernetes/apps/network/cluster-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cluster-dns/app/helmrelease.yaml
@@ -24,10 +24,19 @@ spec:
       - --rfc2136-port=53
       - --rfc2136-zone=cluster.local
       - --rfc2136-batch-change-size=50
+      # external-dns sends TTL 0 when unset, which Technitium stores
+      # faithfully — so every lookup of these names bypasses every
+      # cache. This floor makes them cacheable (service ClusterIPs, more likely to move).
+      - --rfc2136-min-ttl=60s
       - --publish-internal-services
       - --always-publish-not-ready-addresses
       - --fqdn-template={{ "{{" }}.Name{{ "}}" }}.{{ "{{" }}.Namespace{{ "}}" }}.svc.cluster.local
       - --events
+      # The RFC2136 provider re-applies its entire desired state each
+      # cycle rather than diffing, so the default 1m interval rewrote
+      # every record every minute. --events carries real changes
+      # promptly; this sweep is only a safety net.
+      - --interval=10m
     env:
       - name: EXTERNAL_DNS_RFC2136_TSIG_KEYNAME
         valueFrom:

--- a/kubernetes/apps/network/internal-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/internal-dns/app/helmrelease.yaml
@@ -24,10 +24,19 @@ spec:
       - --rfc2136-port=53
       - --rfc2136-zone=vaderrp.com
       - --rfc2136-batch-change-size=50
+      # external-dns sends TTL 0 when unset, which Technitium stores
+      # faithfully — so every lookup of these names bypasses every
+      # cache. This floor makes them cacheable (gateway VIPs, effectively static).
+      - --rfc2136-min-ttl=300s
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint
       - --annotation-filter=external-dns.alpha.kubernetes.io/ignore notin (true)
       - --events
+      # The RFC2136 provider re-applies its entire desired state each
+      # cycle rather than diffing, so the default 1m interval rewrote
+      # every record every minute. --events carries real changes
+      # promptly; this sweep is only a safety net.
+      - --interval=10m
     env:
       - name: EXTERNAL_DNS_RFC2136_TSIG_KEYNAME
         valueFrom:


### PR DESCRIPTION
Chasing why `vaderrp.com`'s SOA serial was climbing so fast turned up two independent problems. external-dns was re-adding **all 42 tracked records every 60 seconds** — roughly 60k zone updates a day, each bumping the serial and firing a NOTIFY to ns2.

## TTL 0 — the more consequential one

Every record was being written with TTL `0`:

```
Adding RR: flux.vaderrp.com 0 A 192.168.7.4
```

That's external-dns's "not configured" sentinel, and Technitium stores it faithfully:

```
;; ANSWER SECTION:
flux.vaderrp.com.       0       IN      A       192.168.7.4
```

**TTL 0 means "never cache."** Every lookup of every internal name — from CoreDNS, from every pod, from every LAN client — has been going all the way to Technitium every single time. The `cache 30` block in the CoreDNS config could not hold a single one of these records.

```diff
+      - --rfc2136-min-ttl=300s   # internal-dns
+      - --rfc2136-min-ttl=60s    # cluster-dns
```

`300s` for `internal-dns`, whose records point at gateway VIPs that effectively never change. `60s` for `cluster-dns`, whose ClusterIPs are more likely to move — a shorter floor there trades a little caching for faster convergence.

## The churn itself

**Not** a TTL mismatch — written and read values agree, so nothing is fighting. The RFC2136 provider simply re-applies its entire desired state each cycle rather than diffing, so the default 1-minute interval rewrote everything every minute.

```diff
+      - --interval=10m
```

Tenfold reduction, and real changes are unaffected: `--events` is already set on both instances and carries those promptly. The periodic sweep is only a safety net for missed events.

## Expected after merge

- The per-minute `Adding RR:` wall in both logs drops to once per 10 minutes
- `vaderrp.com`'s serial advances ~4/hour instead of ~2,500
- `dig` on any internal name returns a non-zero TTL, and repeat lookups start being served from cache

Trade-off worth stating: a record changed *outside* an event now takes up to 10 minutes to correct, and clients may hold a cached answer for up to the TTL. Both are fine for records pointing at static gateway VIPs, and neither affects the event-driven path that publishes new HTTPRoutes.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_