### PR TITLE
fix(external-dns): set interval as a chart value, not an extraArg

### DIFF
--- a/kubernetes/apps/network/cluster-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cluster-dns/app/helmrelease.yaml
@@ -18,6 +18,13 @@ spec:
     remediation:
       retries: 3
   values:
+    # The RFC2136 provider re-applies its entire desired state each cycle
+    # rather than diffing, so the 1m default rewrote every record every
+    # minute. --events carries real changes promptly; this sweep is only a
+    # safety net. Set here rather than in extraArgs: the chart already
+    # renders --interval from this value, and passing both is a fatal
+    # "flag 'interval' cannot be repeated".
+    interval: 10m
     provider: rfc2136
     extraArgs:
       - --rfc2136-host=192.168.7.8
@@ -32,11 +39,6 @@ spec:
       - --always-publish-not-ready-addresses
       - --fqdn-template={{ "{{" }}.Name{{ "}}" }}.{{ "{{" }}.Namespace{{ "}}" }}.svc.cluster.local
       - --events
-      # The RFC2136 provider re-applies its entire desired state each
-      # cycle rather than diffing, so the default 1m interval rewrote
-      # every record every minute. --events carries real changes
-      # promptly; this sweep is only a safety net.
-      - --interval=10m
     env:
       - name: EXTERNAL_DNS_RFC2136_TSIG_KEYNAME
         valueFrom:

--- a/kubernetes/apps/network/internal-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/internal-dns/app/helmrelease.yaml
@@ -18,6 +18,13 @@ spec:
     remediation:
       retries: 3
   values:
+    # The RFC2136 provider re-applies its entire desired state each cycle
+    # rather than diffing, so the 1m default rewrote every record every
+    # minute. --events carries real changes promptly; this sweep is only a
+    # safety net. Set here rather than in extraArgs: the chart already
+    # renders --interval from this value, and passing both is a fatal
+    # "flag 'interval' cannot be repeated".
+    interval: 10m
     provider: rfc2136
     extraArgs:
       - --rfc2136-host=192.168.7.8
@@ -32,11 +39,6 @@ spec:
       - --crd-source-kind=DNSEndpoint
       - --annotation-filter=external-dns.alpha.kubernetes.io/ignore notin (true)
       - --events
-      # The RFC2136 provider re-applies its entire desired state each
-      # cycle rather than diffing, so the default 1m interval rewrote
-      # every record every minute. --events carries real changes
-      # promptly; this sweep is only a safety net.
-      - --interval=10m
     env:
       - name: EXTERNAL_DNS_RFC2136_TSIG_KEYNAME
         valueFrom:


### PR DESCRIPTION
Both `internal-dns` and `cluster-dns` are crashlooping after #1648:

```
level=fatal msg="flag parsing error: flag 'interval' cannot be repeated"
```

The chart already renders `--interval` from its own `interval` value. Adding it to `extraArgs` passed the flag twice, and external-dns treats that as fatal rather than taking the last value.

```diff
   values:
+    interval: 10m
     provider: rfc2136
     extraArgs:
       ...
       - --events
-      - --interval=10m
```

`--rfc2136-min-ttl` is unaffected and stays in `extraArgs` — the chart has no value for it, so there's nothing to collide with.

## Impact while broken

DNS resolution itself was never affected; Technitium serves independently of these pods. What stopped was *publishing* — a new or changed HTTPRoute wouldn't have got a record until this is fixed. Existing records were untouched.

Verified both files parse and that `interval` now appears only as a value.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_