### PR TITLE
refactor(external-dns): enable events via chart value, not extraArgs

### DIFF
--- a/kubernetes/apps/network/cluster-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cluster-dns/app/helmrelease.yaml
@@ -20,11 +20,14 @@ spec:
   values:
     # The RFC2136 provider re-applies its entire desired state each cycle
     # rather than diffing, so the 1m default rewrote every record every
-    # minute. --events carries real changes promptly; this sweep is only a
-    # safety net. Set here rather than in extraArgs: the chart already
-    # renders --interval from this value, and passing both is a fatal
-    # "flag 'interval' cannot be repeated".
+    # minute. Event-driven reconciliation below carries real changes
+    # promptly, leaving this sweep as only a safety net.
+    #
+    # Both of these are chart values rather than extraArgs on purpose: the
+    # chart renders --interval and --events from them, and passing either
+    # flag twice is a fatal "cannot be repeated".
     interval: 10m
+    triggerLoopOnEvent: true
     provider: rfc2136
     extraArgs:
       - --rfc2136-host=192.168.7.8
@@ -38,7 +41,6 @@ spec:
       - --publish-internal-services
       - --always-publish-not-ready-addresses
       - --fqdn-template={{ "{{" }}.Name{{ "}}" }}.{{ "{{" }}.Namespace{{ "}}" }}.svc.cluster.local
-      - --events
     env:
       - name: EXTERNAL_DNS_RFC2136_TSIG_KEYNAME
         valueFrom:

--- a/kubernetes/apps/network/internal-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/internal-dns/app/helmrelease.yaml
@@ -20,11 +20,14 @@ spec:
   values:
     # The RFC2136 provider re-applies its entire desired state each cycle
     # rather than diffing, so the 1m default rewrote every record every
-    # minute. --events carries real changes promptly; this sweep is only a
-    # safety net. Set here rather than in extraArgs: the chart already
-    # renders --interval from this value, and passing both is a fatal
-    # "flag 'interval' cannot be repeated".
+    # minute. Event-driven reconciliation below carries real changes
+    # promptly, leaving this sweep as only a safety net.
+    #
+    # Both of these are chart values rather than extraArgs on purpose: the
+    # chart renders --interval and --events from them, and passing either
+    # flag twice is a fatal "cannot be repeated".
     interval: 10m
+    triggerLoopOnEvent: true
     provider: rfc2136
     extraArgs:
       - --rfc2136-host=192.168.7.8
@@ -38,7 +41,6 @@ spec:
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint
       - --annotation-filter=external-dns.alpha.kubernetes.io/ignore notin (true)
-      - --events
     env:
       - name: EXTERNAL_DNS_RFC2136_TSIG_KEYNAME
         valueFrom:


### PR DESCRIPTION
Two conventions for the same thing across the three external-dns instances:

```yaml
triggerLoopOnEvent: true      # cloudflare-dns — chart value
- --events                    # internal-dns, cluster-dns — extraArgs
```

Both render `--events`. This worked only because `triggerLoopOnEvent` defaults to `false` on the two RFC2136 instances, so the chart emitted nothing to collide with.

**That's a live trap.** Anyone setting `triggerLoopOnEvent: true` on `internal-dns` or `cluster-dns` — a reasonable thing to do, since it's what the third instance does — would hit exactly the fatal that took both pods down in #1648:

```
flag parsing error: flag 'events' cannot be repeated
```

```diff
     interval: 10m
+    triggerLoopOnEvent: true
     provider: rfc2136
     extraArgs:
       ...
-      - --events
```

Behaviourally identical, removes the landmine, and makes all three instances consistent.

Also rewrites the `interval` comment, which named `--events` directly and would have been stale after this.

Validated by parsing all three files: `triggerLoopOnEvent: true` on each, and no `events` flag left in any `extraArgs`.

## Confirming the earlier change landed

```
;; ANSWER SECTION:
flux.vaderrp.com.       300     IN      A       192.168.7.4
```

`--rfc2136-min-ttl` from #1648 is working — internal names are cacheable for the first time.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_