### PR TITLE
fix(gpro): stop the Kustomizations reconciling back-to-back

### DIFF
--- a/kubernetes/apps/gpro/gpro/app/resourceset.yaml
+++ b/kubernetes/apps/gpro/gpro/app/resourceset.yaml
@@ -36,7 +36,14 @@ spec:
         interval: 5m
         prune: true
         wait: true
-        timeout: 5m
+        # timeout must stay well under interval. With both at 5m, a health
+        # check that ran to timeout consumed the whole interval, so the next
+        # reconcile started the instant the previous one gave up — the
+        # Kustomization never left Reconciling and never showed a settled
+        # failure. retryInterval is explicit for the same reason: it defaults
+        # to interval, and the gap after a failure is the point.
+        timeout: 2m
+        retryInterval: 5m
         force: true
         decryption:
           provider: sops


### PR DESCRIPTION
The two gpro Kustomizations were the pair stuck in "reconciliation limbo" — finishing and immediately restarting, never settling into a state you could read.

```diff
         wait: true
-        timeout: 5m
+        timeout: 2m
+        retryInterval: 5m
```

## Why they never settled

`timeout` and `interval` were **both 5m**. `wait: true` health-checks everything the Kustomization applies, including the two ExternalSecrets, which were stuck `InProgress`. So the check ran the full 5 minutes — by which point the interval had already elapsed, and the next reconcile fired with no gap at all.

That's the loop. Not a Flux bug, just two timers set to the same value where one has to be shorter than the other.

2m timeout with an explicit `retryInterval: 5m` leaves a real 3-minute gap after a failure. `retryInterval` is spelled out rather than left to default precisely because it *defaults to `interval`* — the same collision, one layer down.

## The underlying failure

Real, and not cosmetic: a `redis_password` lookup against a Vaultwarden item the secret store could no longer resolve. Fixed separately in [operinko-labs/gpro](https://github.com/operinko-labs/gpro) — this change doesn't fix it, it makes the *next* one visible.

Worth noting how narrowly it was caught. 43 other Kustomizations in this repo run `wait: false`; gpro is the only one that health-checks, which is the only reason anything surfaced. The app itself kept working the whole time because the ExternalSecret sets `deletionPolicy: Retain`, so the Secret held values from the last successful sync.

## What to expect

Both should go `Ready` once the gpro PR merges. If a sync genuinely breaks later, they'll now report `Failed` and **stay** there instead of churning.

`force: true` left alone — worth a look at some point, but it's a separate question from the timing.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_