### PR TITLE
feat(observability): alert on ExternalSecret health; wait on dependencies

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -17,7 +17,9 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false # Default false for speed, enable for critical
+  # cert-manager-issuers depends on this; an Issuer applied before the CRDs
+  # are established just errors and retries.
+  wait: true
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -17,7 +17,12 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false
+  # This one Kustomization applies the operator, the Cluster and its
+  # ExternalSecrets together, so waiting covers Postgres actually reaching
+  # Ready rather than just the operator being installed.
+  wait: true
   interval: 30m
   retryInterval: 1m
-  timeout: 5m
+  # 10m rather than 5m: a Cluster is briefly not-Ready during switchover and
+  # minor-version upgrades, and this shouldn't trip on routine operations.
+  timeout: 10m

--- a/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -20,3 +20,11 @@ spec:
       retries: 3
   values:
     installCRDs: true
+    # Without this the controller exports externalsecret_status_condition and
+    # nothing scrapes it, so the grafanadashboard alongside this file has been
+    # rendering empty and no alert on ExternalSecret health was possible.
+    # Enabling the ServiceMonitor also renders the metrics Service the chart
+    # otherwise leaves off — metrics.service.enabled is not needed as well.
+    serviceMonitor:
+      enabled: true
+      interval: 1m

--- a/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ocirepository.yaml
   - pdb.yaml
   - grafanadashboard.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/external-secrets/external-secrets/app/prometheusrule.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/prometheusrule.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: external-secrets
+spec:
+  groups:
+    - name: external-secrets.rules
+      rules:
+        # A failing ExternalSecret is otherwise invisible. Its Kustomization
+        # stays Ready (the manifest applied fine), the HelmRelease stays Ready,
+        # and every app here sets deletionPolicy: Retain — so the Secret keeps
+        # the values from the last successful sync and the workload carries on
+        # against stale data. Only the ~22 Kustomizations that set wait: true
+        # surface it at all, and then only as a health-check timeout.
+        - alert: ExternalSecretNotReady
+          expr: |-
+            externalsecret_status_condition{condition="Ready",status="False"} == 1
+          annotations:
+            summary: >-
+              ExternalSecret {{ $labels.namespace }}/{{ $labels.name }} has not
+              synced; its Secret is serving the last values that did sync
+          for: 15m
+          labels:
+            severity: warning
+
+        # The usual upstream cause of the above. bw serve losing its session,
+        # the Vaultwarden endpoint being unreachable, or a bad credential takes
+        # out every ExternalSecret behind the store at once.
+        - alert: ClusterSecretStoreNotReady
+          expr: |-
+            clustersecretstore_status_condition{condition="Ready",status="False"} == 1
+          annotations:
+            summary: >-
+              ClusterSecretStore {{ $labels.name }} is not ready; every
+              ExternalSecret using it will fail to refresh
+          for: 10m
+          labels:
+            severity: critical
+
+        # Deliberately keyed on the metric rather than up{job="..."}: the job
+        # label depends on how the ServiceMonitor names its target, and an
+        # absent() on a label that never matches fires forever and gets muted.
+        # This series exists whenever ESO is scraped and any ExternalSecret
+        # exists, which is the condition we actually care about.
+        - alert: ExternalSecretsMetricsAbsent
+          expr: |-
+            absent(externalsecret_status_condition)
+          annotations:
+            summary: >-
+              external-secrets is not being scraped; the ExternalSecret alerts
+              above cannot fire while this is true
+          for: 15m
+          labels:
+            severity: critical

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -17,7 +17,9 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false
+  # volsync depends on this, and VolSync's whole job is driving
+  # VolumeSnapshots — it has nothing to do until this controller is up.
+  wait: true
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/observability/vpa/ks.yaml
+++ b/kubernetes/apps/observability/vpa/ks.yaml
@@ -17,7 +17,9 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false
+  # 15 Kustomizations depend on this one and apply VerticalPodAutoscaler
+  # objects. Waiting on health means the CRD is established before they try.
+  wait: true
   interval: 30m
   retryInterval: 1m
-  timeout: 5m
+  timeout: 10m

--- a/kubernetes/apps/storage/volsync/ks.yaml
+++ b/kubernetes/apps/storage/volsync/ks.yaml
@@ -20,10 +20,19 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false # Default false for speed, enable for critical
+  # 26 Kustomizations depend on this one, and dependsOn only waits for the
+  # dependency to be *applied* unless it waits on health. Without this they
+  # were free to create ReplicationSources the moment VolSync's manifests
+  # landed — before its CRDs were established or its controller was running.
+  # Self-healing via retries, but noisy, and it made "volsync is Ready" mean
+  # nothing. Accepted trade: a genuinely broken VolSync now stalls those 26
+  # Kustomizations' deploys rather than letting them proceed unprotected.
+  wait: true
   interval: 30m
   retryInterval: 1m
-  timeout: 5m
+  # Headroom over the 5m used elsewhere: this is a first-install-heavy chart
+  # and 26 dependents are behind it. Must stay well under interval.
+  timeout: 10m
   postBuild:
     substitute:
       APP: volsync


### PR DESCRIPTION
Working out which Kustomizations should use `wait: true` turned up two gaps, and the answer to the original question is mostly "not `wait`."

## 1. A failing ExternalSecret produces no signal anywhere

gpro's `redis_password` lookup had been failing since **2026-06-05** and nothing reported it. The Kustomization stayed `Ready` — the manifest applied fine. The HelmRelease stayed `Ready`. `deletionPolicy: Retain` kept the Secret serving the last values that did sync, so the app carried on. **~22 Kustomizations apply an ExternalSecret with `wait: false` and share that blind spot.**

external-secrets exports exactly the metric for this, but the chart leaves its metrics Service and ServiceMonitor off by default and neither was enabled:

```diff
   values:
     installCRDs: true
+    serviceMonitor:
+      enabled: true
+      interval: 1m
```

Confirmed against chart 2.0.0: `serviceMonitor.enabled` renders **both** the ServiceMonitor and the metrics Service (`if or .Values.metrics.service.enabled (and .Values.serviceMonitor.enabled ...)`), so `metrics.service.enabled` isn't needed too.

Side effect worth noting: the `grafanadashboard.yaml` sitting next to the HelmRelease pulls the upstream ESO dashboard, whose panels query `externalsecret_status_condition` and `controller_runtime_reconcile_total`. **It has been rendering empty this whole time.** It should populate after this.

New `prometheusrule.yaml`, three alerts:

| Alert | Expr | for | severity |
|---|---|---|---|
| `ExternalSecretNotReady` | `externalsecret_status_condition{condition="Ready",status="False"} == 1` | 15m | warning |
| `ClusterSecretStoreNotReady` | `clustersecretstore_status_condition{condition="Ready",status="False"} == 1` | 10m | critical |
| `ExternalSecretsMetricsAbsent` | `absent(externalsecret_status_condition)` | 15m | critical |

Label casing (`condition="Ready"`, `status="False"` — capitalised) taken from the upstream dashboard rather than guessed.

The third is keyed on the metric rather than `up{job="..."}` deliberately. The `job` label depends on how the ServiceMonitor names its target; an `absent()` on a label that never matches fires forever, gets muted, and then the other two alerts are silently unprotected. This series exists whenever ESO is scraped and any ExternalSecret exists, which is the condition we actually care about.

One rule covers all ~60 ExternalSecrets, blocks nothing, and needs no per-app edits. It would have fired on June 5th.

## 2. `dependsOn` was not waiting for health

`dependsOn` gates on the dependency being `Ready` — and with `wait: false`, `Ready` means *applied*, not *healthy*. Dependents were free to create CRs before the CRDs existed. Self-healing via retries, but noisy, and it made "volsync is Ready" mean nothing.

| Kustomization | Dependents | Change |
|---|---|---|
| `volsync` | **26** | `wait: true`, timeout 5m → 10m |
| `vpa` | **15** | `wait: true`, timeout 5m → 10m |
| `cloudnative-pg` | 1 | `wait: true`, timeout 5m → 10m |
| `cert-manager` | 1 | `wait: true` |
| `snapshot-controller` | 1 | `wait: true` |

Its own comment said the quiet part — `wait: false # Default false for speed, enable for critical`.

Timeout bumps are headroom for first install and, for CNPG, for a `Cluster` being briefly not-`Ready` during switchover or a minor-version upgrade — this shouldn't trip on routine operations. All stay well under their 30m interval; verified programmatically that **no** Kustomization now has `timeout >= interval`, since that collision is precisely what stopped gpro from ever holding `Ready=False` long enough for `FluxReconciliationFailure` (`for: 10m`) to fire.

Accepted trade on `volsync`: a genuinely broken VolSync now stalls those 26 Kustomizations' deploys instead of letting them proceed unprotected.

## What I deliberately did not change

**The ~25 `volsync-kopia` apps.** That component's PVC uses `dataSourceRef: ReplicationDestination` on `local-path` (WaitForFirstConsumer), so during a **restore** it sits `Pending` while VolSync repopulates from kopia — which on a large volume outlasts any sane timeout. Blanket `wait: true` there would turn every restore into timeout churn and false alerts, on the one operation you least want noise during.

`stalwart` is skipped for that reason despite having 2 dependents: it holds the mail volume, the slowest one to restore.

**The 26 leaf HelmRelease-only Kustomizations** (`traefik`, `loki`, `coredns`, `internal-dns`…). helm-controller already waits on workloads by default, so `flux get hr -A` surfaces that health. `wait: true` there mostly buys reconcile latency.

## After merging

`flux get ks -A` will be slower to settle on first reconcile — that's the point. Worth spot-checking that the ESO dashboard populates and that `ExternalSecretsMetricsAbsent` resolves rather than firing, which is the one alert here that would indicate I got the ServiceMonitor wiring wrong.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HxSmjcVhnzYvKFpvCYM6b)_