### PR TITLE
feat(media): drop ribbon overlay from movies

### DIFF
--- a/kubernetes/apps/media/kometa/app/config.yaml
+++ b/kubernetes/apps/media/kometa/app/config.yaml
@@ -37,8 +37,6 @@ libraries:
       - default: runtimes
       # Common Sense age rating badge
       - default: commonsense
-      # Award/chart ribbons (Oscars, IMDb Top 250, ...)
-      - default: ribbon
       # Languages spoken and subtitles with associated flags and two-digit lang codes
       - default: languages
       # Languages spoken and subtitles with associated flags and two-digit lang codes


### PR DESCRIPTION
## Summary

Removes the award/chart ribbon overlay (`default: ribbon`) from the Movies library in the Kometa config. Movies keep the remaining overlays: resolution, audio codec, ratings, video format, runtimes, Common Sense age badge, and the two language overlays. TV Shows are unaffected (they never had the ribbon).

Redo of #1675, which was mistakenly stacked on the #1600 branch and merged into it instead of `main` — this PR targets `main` directly so the change goes live independently of #1600. When #1600 later merges, the same removal on its branch resolves cleanly (identical content).

## Changes

- `kubernetes/apps/media/kometa/app/config.yaml`: remove the `- default: ribbon` entry (and its comment) from `libraries.Movies.overlay_files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxtGtseBXhVdPVPNvBPKjR)_